### PR TITLE
lint and reformat with fourmolu

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,165 @@
+{
+  "nodes": {
+    "flake-compat": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1673956053,
+        "narHash": "sha256-4gtG9iQuiKITOjNQQeQIpoIB6b16fm+504Ch3sNKLd8=",
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "rev": "35bb57c0c8d8b62bbfd284272c928ceb64ddbde9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "edolstra",
+        "repo": "flake-compat",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "locked": {
+        "lastModified": 1667395993,
+        "narHash": "sha256-nuEHfE/LcWyuSWnS8t12N1wc105Qtau+/OdUAjtQ0rA=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "5aed5285a952e0b949eb3ba02c12fa4fcfef535f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "gitignore": {
+      "inputs": {
+        "nixpkgs": [
+          "pre-commit-hooks",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1660459072,
+        "narHash": "sha256-8DFJjXG8zqoONA1vXtgeKXy68KdJL5UaXR8NtVMUbx8=",
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "rev": "a20de23b925fd8264fd7fad6454652e142fd7f73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "gitignore.nix",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1675279076,
+        "narHash": "sha256-I8sMB4TBkhNY4lcKtb+pwEDB50My3+JG5Ti8J3sEmCc=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "c6fd903606866634312e40cceb2caee8c0c9243f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "ref": "nixpkgs-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1673800717,
+        "narHash": "sha256-SFHraUqLSu5cC6IxTprex/nTsI81ZQAtDvlBvGDWfnA=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "2f9fd351ec37f5d479556cd48be4ca340da59b8f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_2": {
+      "locked": {
+        "lastModified": 1671271357,
+        "narHash": "sha256-xRJdLbWK4v2SewmSStYrcLa0YGJpleufl44A19XSW8k=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "40f79f003b6377bd2f4ed4027dde1f8f922995dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pre-commit-hooks": {
+      "inputs": {
+        "flake-compat": "flake-compat",
+        "flake-utils": [
+          "flake-utils"
+        ],
+        "gitignore": "gitignore",
+        "nixpkgs": "nixpkgs_2",
+        "nixpkgs-stable": "nixpkgs-stable"
+      },
+      "locked": {
+        "lastModified": 1675337566,
+        "narHash": "sha256-jmLBTQcs1jFOn8h1Q5b5XwPfYgFOtcZ3+mU9KvfC6Js=",
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "rev": "5668d079583a5b594cb4e0cc0e6d84f1b93da7ae",
+        "type": "github"
+      },
+      "original": {
+        "owner": "cachix",
+        "repo": "pre-commit-hooks.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": "nixpkgs",
+        "pre-commit-hooks": "pre-commit-hooks",
+        "servant-pandoc": "servant-pandoc",
+        "servant-py": "servant-py"
+      }
+    },
+    "servant-pandoc": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675182069,
+        "narHash": "sha256-QFRutQx/XuugO8fAHGpdJ5FFLd7BdBFpao+Ekhf530s=",
+        "path": "/home/shae/build/servant-pandoc",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/shae/build/servant-pandoc",
+        "type": "path"
+      }
+    },
+    "servant-py": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1675119078,
+        "narHash": "sha256-+O8bXzc+WjvD9YQao9TTtiAfzsZKEb6dt2/umsv7oAw=",
+        "path": "/home/shae/build/servant-py",
+        "type": "path"
+      },
+      "original": {
+        "path": "/home/shae/build/servant-py",
+        "type": "path"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,80 @@
+{
+  description = "haskell-tahoe-lafs-storage-server";
+
+  inputs = {
+    # Nix Inputs
+    nixpkgs.url = github:nixos/nixpkgs/nixpkgs-unstable;
+
+    statvfs = {
+      url = github:shapr/statvfs;
+      flake = false;
+    };
+
+    flake-utils.url = github:numtide/flake-utils;
+    pre-commit-hooks.url = github:cachix/pre-commit-hooks.nix;
+    pre-commit-hooks.inputs.flake-utils.follows = "flake-utils";
+  };
+
+  outputs = {
+    self,
+    nixpkgs,
+    pre-commit-hooks,
+    flake-utils,
+    statvfs,
+  }: let
+    utils = flake-utils.lib;
+  in
+    utils.eachDefaultSystem (system: let
+      compilerVersion = "ghc8107";
+      pkgs = nixpkgs.legacyPackages.${system};
+      hsPkgs = pkgs.haskell.packages.${compilerVersion}.override {
+        overrides = hfinal: hprev: {
+          haskell-tahoe-lafs-storage-server = hfinal.callCabal2nix "haskell-tahoe-lafs-storage-server" ./. {};
+          servant-pandoc = hfinal.callCabal2nix "servant-pandoc" servant-pandoc {};
+          servant-py = hfinal.callCabal2nix "servant-py" servant-py {};
+          statvfs = hfinal.callCabal2nix "statvfs" statvfs {};
+        };
+      };
+    in rec {
+      packages =
+        utils.flattenTree
+        {haskell-tahoe-lafs-storage-server = hsPkgs.haskell-tahoe-lafs-storage-server;};
+
+      # nix flake check
+      checks = {
+        pre-commit-check = pre-commit-hooks.lib.${system}.run {
+          src = ./.;
+          hooks = {
+            alejandra.enable = true;
+            fourmolu.enable = true;
+            cabal-fmt.enable = true;
+          };
+        };
+      };
+
+      # nix develop
+      devShell = hsPkgs.shellFor {
+        inherit (self.checks.${system}.pre-commit-check) shellHook;
+        withHoogle = true;
+        packages = p: [
+          p.haskell-tahoe-lafs-storage-server
+        ];
+        buildInputs = with pkgs;
+          [
+            hsPkgs.haskell-language-server
+            haskellPackages.cabal-install
+            cabal2nix
+            haskellPackages.hasktags
+            haskellPackages.ghcid
+            haskellPackages.fourmolu
+            haskellPackages.ormolu
+            haskellPackages.cabal-fmt
+            nodePackages.serve
+          ]
+          ++ (builtins.attrValues (import ./scripts.nix {s = pkgs.writeShellScriptBin;}));
+      };
+
+      # nix build
+      defaultPackage = packages.haskell-tahoe-lafs-storage-server;
+    });
+}

--- a/generate-apidocs/Main.hs
+++ b/generate-apidocs/Main.hs
@@ -1,56 +1,56 @@
 module Main where
 
-import Prelude hiding
-  ( putStrLn
-  )
+import Prelude hiding (
+    putStrLn,
+ )
 
-import Data.Text
-  ( Text
-  , unpack
-  , pack
-  )
+import Data.Text (
+    Text,
+    pack,
+    unpack,
+ )
 
-import Data.Text.IO
-  ( putStrLn
-  )
+import Data.Text.IO (
+    putStrLn,
+ )
 
-import Text.Pandoc.Class
-  ( PandocIO
-  , runIOorExplode
-  )
+import Text.Pandoc.Class (
+    PandocIO,
+    runIOorExplode,
+ )
 
-import Text.Pandoc.Writers.HTML
-  ( writeHtml5String
-  )
+import Text.Pandoc.Writers.HTML (
+    writeHtml5String,
+ )
 
-import Text.Blaze.Html.Renderer.Pretty
-  ( renderHtml
-  )
+import Text.Blaze.Html.Renderer.Pretty (
+    renderHtml,
+ )
 
-import Servant.Docs
-  ( docs
-  )
+import Servant.Docs (
+    docs,
+ )
 
-import Servant.Docs.Pandoc
-  ( pandoc
-  )
+-- import Servant.Docs.Pandoc
+--   ( pandoc
+--   )
 
-import Data.Default
-  ( def
-  )
+import Data.Default (
+    def,
+ )
 
 -- Import for instances only.
-import TahoeLAFS.Storage.APIDocs
-  (
-  )
+import TahoeLAFS.Storage.APIDocs (
 
-import TahoeLAFS.Storage.API
-  ( api
-  )
+ )
+
+import TahoeLAFS.Storage.API (
+    api,
+ )
 
 main :: IO ()
 main = do
-  let doc = pandoc $ docs $ api
-  let markup = writeHtml5String def doc
-  html <- runIOorExplode markup
-  putStrLn html
+    let doc = pandoc $ docs $ api
+    let markup = writeHtml5String def doc
+    html <- runIOorExplode markup
+    putStrLn html

--- a/generate-clients/Main.hs
+++ b/generate-clients/Main.hs
@@ -1,35 +1,35 @@
 module Main where
 
-import System.FilePath
-  ( FilePath
-  , (</>)
-  )
+import System.FilePath (
+    FilePath,
+    (</>),
+ )
 
-import Servant.JS
-  ( writeJSForAPI
-  , angular
-  , defAngularOptions
-  , vanillaJS
-  , jquery
-  )
+import Servant.JS (
+    angular,
+    defAngularOptions,
+    jquery,
+    vanillaJS,
+    writeJSForAPI,
+ )
 
-import Servant.PY
-  ( writePythonForAPI
-  , requests
-  , treq
-  )
+-- import Servant.PY
+--   ( writePythonForAPI
+--   , requests
+--   , treq
+--   )
 
-import TahoeLAFS.Storage.API
-  ( api
-  )
+import TahoeLAFS.Storage.API (
+    api,
+ )
 
 result :: FilePath
 result = "./"
 
 main :: IO ()
 main = do
-    writePythonForAPI api requests (result </> "requests_api.py")
-    writePythonForAPI api treq (result </> "treq_api.py")
+    -- writePythonForAPI api requests (result </> "requests_api.py")
+    -- writePythonForAPI api treq (result </> "treq_api.py")
 
     writeJSForAPI api (angular defAngularOptions) (result </> "angular_api.js")
     writeJSForAPI api vanillaJS (result </> "vanilla_api.js")

--- a/scripts.nix
+++ b/scripts.nix
@@ -1,0 +1,5 @@
+{s}: rec
+{
+  ghcidScript = s "dev" "ghcid --command 'cabal new-repl lib:haskell-tahoe-lafs-storage-server' --allow-eval --warnings";
+  allScripts = [ghcidScript];
+}

--- a/src/TahoeLAFS/Internal/ServantUtil.hs
+++ b/src/TahoeLAFS/Internal/ServantUtil.hs
@@ -2,91 +2,87 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
 
-module TahoeLAFS.Internal.ServantUtil
-  ( CBOR
-  ) where
+module TahoeLAFS.Internal.ServantUtil (
+    CBOR,
+) where
 
-import Network.HTTP.Media
-  ( (//)
-  )
+import Network.HTTP.Media (
+    (//),
+ )
 
-import Data.ByteString
-  ( ByteString
-  )
+import Data.ByteString (
+    ByteString,
+ )
 
-import Data.ByteString.Base64
-  ( encode
-  , decode
-  )
+import Data.ByteString.Base64 (
+    decode,
+    encode,
+ )
 
-import Data.Text.Encoding
-  ( decodeUtf8
-  , encodeUtf8
-  )
+import Data.Text.Encoding (
+    decodeUtf8,
+    encodeUtf8,
+ )
 
-import Data.ByteString.UTF8
-  ( toString
-  , fromString
-  )
+import Servant (
+    Accept (..),
+    MimeRender (..),
+    MimeUnrender (..),
+ )
 
-import Servant
-  ( Accept(..)
-  , MimeRender(..)
-  , MimeUnrender(..)
-  )
+import Data.Aeson (
+    FromJSON (parseJSON),
+    ToJSON (toJSON),
+    withText,
+ )
+import Data.Aeson.Types (
+    Parser,
+    Result (Error, Success),
+    Value (String),
+    fromJSON,
+ )
 
-import Data.Aeson
-  ( ToJSON(toJSON)
-  , FromJSON(parseJSON)
-  , withText
-  )
-import Data.Aeson.Types
-  ( Parser
-  , Result(Error, Success)
-  , fromJSON
-  , Value(String)
-  )
+import Codec.CBOR.Write (
+    toLazyByteString,
+ )
 
-import Codec.CBOR.Write
-  ( toLazyByteString
-  )
+import Codec.CBOR.Read (
+    deserialiseFromBytes,
+ )
 
-import Codec.CBOR.Read
-  ( deserialiseFromBytes
-  )
-
-import Codec.CBOR.JSON
-  ( encodeValue
-  , decodeValue
-  )
+import Codec.CBOR.JSON (
+    decodeValue,
+    encodeValue,
+ )
 
 data CBOR
 
 instance Accept CBOR where
-  -- https://tools.ietf.org/html/rfc7049#section-7.3
-  contentType _ = "application" // "cbor"
+    -- https://tools.ietf.org/html/rfc7049#section-7.3
+    contentType _ = "application" // "cbor"
 
 instance ToJSON a => MimeRender CBOR a where
-  mimeRender _ val = toLazyByteString $ encodeValue $ toJSON val
+    mimeRender _ val = toLazyByteString $ encodeValue $ toJSON val
 
 instance FromJSON a => MimeUnrender CBOR a where
-  mimeUnrender _ bytes =
-    case deserialiseFromBytes (decodeValue False) bytes of
-      Right ("", val)  ->
-        case fromJSON val of
-          Error s   -> Left s
-          Success x -> Right x
-      Right (extra, _) -> Left "extra bytes at tail"
-      Left err         -> Left $ show err
-
+    mimeUnrender _ bytes =
+        case deserialiseFromBytes (decodeValue False) bytes of
+            Right ("", val) ->
+                case fromJSON val of
+                    Error s -> Left s
+                    Success x -> Right x
+            Right (extra, _) -> Left "extra bytes at tail"
+            Left err -> Left $ show err
 
 instance ToJSON ByteString where
-  toJSON bs = String $ decodeUtf8 $ encode bs
+    toJSON bs = String $ decodeUtf8 $ encode bs
 
 instance FromJSON ByteString where
-  parseJSON = withText "String" (
-    \bs ->
-      case decode $ encodeUtf8 bs of
-        Left err    -> fail ("Base64 decoding failed: " ++ err)
-        Right bytes -> return bytes
-    )
+    parseJSON =
+        withText
+            "String"
+            ( \bs ->
+                case decode $ encodeUtf8 bs of
+                    Left err -> fail ("Base64 decoding failed: " ++ err)
+                    Right bytes -> return bytes
+            )

--- a/src/TahoeLAFS/Storage/API.hs
+++ b/src/TahoeLAFS/Storage/API.hs
@@ -1,128 +1,125 @@
 {-# LANGUAGE DataKinds #-}
-{-# LANGUAGE TypeOperators #-}
+-- https://artyom.me/aeson#records-and-json-generics
+{-# LANGUAGE DeriveAnyClass #-}
+-- https://artyom.me/aeson#records-and-json-generics
+{-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleInstances #-}
-{-# LANGUAGE OverloadedStrings #-}
 -- Supports derivations for ShareNumber
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
--- https://artyom.me/aeson#records-and-json-generics
-{-# LANGUAGE DeriveGeneric, DeriveAnyClass #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TypeOperators #-}
 
-module TahoeLAFS.Storage.API
-  ( Version(..)
-  , Size
-  , Offset
-  , StorageIndex
-  , ShareNumber(ShareNumber)
-  , shareNumber
-  , toInteger
-  , ShareData
-  , ApplicationVersion(..)
-  , Version1Parameters(..)
-  , AllocateBuckets(..)
-  , AllocationResult(..)
-  , TestWriteVectors(..)
-  , WriteVector(..)
-  , ReadTestWriteVectors(..)
-  , ReadTestWriteResult(..)
-  , ReadVectors
-  , ReadVector
-  , TestVector(TestVector)
-  , WriteVector(WriteVector)
-  , ReadResult
-  , CorruptionDetails(CorruptionDetails)
-  , SlotSecrets(..)
-  , TestOperator(..)
-  , StorageAPI
-  , api
-  , renewSecretLength
-  , writeEnablerSecretLength
-  , leaseRenewSecretLength
-  , leaseCancelSecretLength
-  ) where
+module TahoeLAFS.Storage.API (
+    Version (..),
+    Size,
+    Offset,
+    StorageIndex,
+    ShareNumber (ShareNumber),
+    shareNumber,
+    toInteger,
+    ShareData,
+    ApplicationVersion,
+    Version1Parameters (..),
+    AllocateBuckets (..),
+    AllocationResult (..),
+    TestWriteVectors (..),
+    WriteVector (..),
+    ReadTestWriteVectors (..),
+    ReadTestWriteResult (..),
+    ReadVectors,
+    ReadVector,
+    TestVector (TestVector),
+    ReadResult,
+    CorruptionDetails (CorruptionDetails),
+    SlotSecrets (..),
+    TestOperator (..),
+    StorageAPI,
+    api,
+    renewSecretLength,
+    writeEnablerSecretLength,
+    leaseRenewSecretLength,
+    leaseCancelSecretLength,
+) where
 
-import Prelude hiding
-  ( toInteger
-  )
+import Prelude hiding (
+    toInteger,
+ )
 
-import Data.Scientific
-  ( toBoundedInteger
-  )
+import Data.Text (
+    pack,
+    unpack,
+ )
+import Data.Text.Encoding (
+    decodeUtf8,
+ )
 
-import Data.Text
-  ( unpack
-  , pack
-  )
-import Data.Text.Encoding
-  ( decodeUtf8
-  )
+import Data.ByteString (
+    ByteString,
+ )
+import Data.Map.Strict (
+    Map,
+ )
 
-import Data.Map.Strict
-  ( Map
-  )
-import Data.ByteString
-  ( ByteString
-  )
-import Data.Aeson
-  ( ToJSON(..)
-  , FromJSON(..)
-  , ToJSONKey(..)
-  , FromJSONKey(..)
-  , Value(Number)
-  , defaultOptions
-  , camelTo2
-  , genericToJSON
-  , genericParseJSON
-  , fieldLabelModifier
-  )
-import Data.Aeson.Types
-  ( toJSONKeyText
-  )
+import Data.Aeson (
+    FromJSON (..),
+    FromJSONKey (..),
+    ToJSON (..),
+    ToJSONKey (..),
+    camelTo2,
+    defaultOptions,
+    fieldLabelModifier,
+    genericParseJSON,
+    genericToJSON,
+ )
 
-import Text.Read
-  ( readMaybe
-  )
-import GHC.Generics
-  ( Generic
-  )
-import Servant
-  ( Proxy(Proxy)
-  , JSON
-  , OctetStream
-  , Capture
-  , QueryParams
-  , ReqBody
-  , Header
-  , Get
-  , Post
-  , Put
-  , PostCreated
-  , Verb
-  , StdMethod(PUT)
-  , (:>)
-  , (:<|>)
-  )
+import Data.Aeson.Types (
+    toJSONKeyText,
+ )
 
-import Web.HttpApiData
-  ( FromHttpApiData(..)
-  , ToHttpApiData(..)
-  )
+import GHC.Generics (
+    Generic,
+ )
+import Servant (
+    Capture,
+    Get,
+    Header,
+    JSON,
+    OctetStream,
+    Post,
+    PostCreated,
+    Proxy (Proxy),
+    QueryParams,
+    ReqBody,
+    StdMethod (PUT),
+    Verb,
+    (:<|>),
+    (:>),
+ )
+import Text.Read (
+    readMaybe,
+ )
 
-import Network.HTTP.Types
-  ( ByteRange
-  , ByteRanges
-  , parseByteRanges
-  , renderByteRanges
-  )
+import Web.HttpApiData (
+    FromHttpApiData (..),
+    ToHttpApiData (..),
+ )
 
-import TahoeLAFS.Internal.ServantUtil
-  ( CBOR
-  )
+import Network.HTTP.Types (
+    ByteRanges,
+    parseByteRanges,
+    renderByteRanges,
+ )
+
+import TahoeLAFS.Internal.ServantUtil (
+    CBOR,
+ )
 
 type PutCreated = Verb 'PUT 201
 
-tahoeJSONOptions = defaultOptions
-  { fieldLabelModifier = camelTo2 '-'
-  }
+tahoeJSONOptions =
+    defaultOptions
+        { fieldLabelModifier = camelTo2 '-'
+        }
 
 -- The expected lengths of the secrets represented as opaque byte strings.
 -- I haven't checked that these values are correct according to Tahoe-LAFS.
@@ -138,6 +135,7 @@ leaseCancelSecretLength = 32
 type ApplicationVersion = String
 type Size = Integer
 type Offset = Integer
+
 -- TODO These should probably all be byte strings instead.
 type RenewSecret = String
 type CancelSecret = String
@@ -145,264 +143,269 @@ type StorageIndex = String
 type ShareData = ByteString
 
 newtype ShareNumber = ShareNumber Integer
-  deriving
-    ( Show, Generic
-    , Eq, Ord
-    , ToJSON, FromJSON, FromJSONKey
-    , ToHttpApiData
-    )
+    deriving
+        ( Show
+        , Generic
+        , Eq
+        , Ord
+        , ToJSON
+        , FromJSON
+        , FromJSONKey
+        , ToHttpApiData
+        )
 
 instance FromHttpApiData ShareNumber where
-  parseUrlPiece t =
-    case readMaybe $ unpack t of
-      Nothing -> Left "failed to parse"
-      Just i  -> case shareNumber i of
-        Nothing -> Left "number out of bounds"
-        Just s  -> Right s
-  parseQueryParam = parseUrlPiece
-  parseHeader     = parseUrlPiece . decodeUtf8
+    parseUrlPiece t =
+        case readMaybe $ unpack t of
+            Nothing -> Left "failed to parse"
+            Just i -> case shareNumber i of
+                Nothing -> Left "number out of bounds"
+                Just s -> Right s
+    parseQueryParam = parseUrlPiece
+    parseHeader = parseUrlPiece . decodeUtf8
 
 instance ToJSONKey ShareNumber where
-  toJSONKey = toJSONKeyText (pack . show)
+    toJSONKey = toJSONKeyText (pack . show)
 
 shareNumber :: Integer -> Maybe ShareNumber
 shareNumber n =
-  if n < 0 then
-    Nothing
-  else
-    Just $ ShareNumber n
+    if n < 0
+        then Nothing
+        else Just $ ShareNumber n
 
 toInteger :: ShareNumber -> Integer
 toInteger (ShareNumber i) = i
 
 data Version1Parameters = Version1Parameters
-  { maximumImmutableShareSize                 :: Size
-  , maximumMutableShareSize                   :: Size
-  , availableSpace                            :: Size
-  , toleratesImmutableReadOverrun             :: Bool
-  , deleteMutableSharesWithZeroLengthWritev   :: Bool
-  , fillsHolesWithZeroBytes                   :: Bool
-  , preventsReadPastEndOfShareData            :: Bool
-  , httpProtocolAvailable                     :: Bool
-  } deriving (Show, Eq, Generic)
+    { maximumImmutableShareSize :: Size
+    , maximumMutableShareSize :: Size
+    , availableSpace :: Size
+    , toleratesImmutableReadOverrun :: Bool
+    , deleteMutableSharesWithZeroLengthWritev :: Bool
+    , fillsHolesWithZeroBytes :: Bool
+    , preventsReadPastEndOfShareData :: Bool
+    , httpProtocolAvailable :: Bool
+    }
+    deriving (Show, Eq, Generic)
 
 instance ToJSON Version1Parameters where
-  toJSON = genericToJSON tahoeJSONOptions
+    toJSON = genericToJSON tahoeJSONOptions
 
 instance FromJSON Version1Parameters where
-  parseJSON = genericParseJSON tahoeJSONOptions
+    parseJSON = genericParseJSON tahoeJSONOptions
 
 data Version = Version
-  { applicationVersion :: ApplicationVersion
-  , parameters         :: Version1Parameters
-  } deriving (Show, Eq, Generic)
+    { applicationVersion :: ApplicationVersion
+    , parameters :: Version1Parameters
+    }
+    deriving (Show, Eq, Generic)
 
 instance ToJSON Version where
-  toJSON = genericToJSON tahoeJSONOptions
+    toJSON = genericToJSON tahoeJSONOptions
 
 instance FromJSON Version where
-  parseJSON = genericParseJSON tahoeJSONOptions
+    parseJSON = genericParseJSON tahoeJSONOptions
 
 data AllocateBuckets = AllocateBuckets
-  { renewSecret       :: RenewSecret
-  , cancelSecret      :: CancelSecret
-  , shareNumbers      :: [ShareNumber]
-  , allocatedSize     :: Size
-  } deriving (Show, Eq, Generic)
+    { renewSecret :: RenewSecret
+    , cancelSecret :: CancelSecret
+    , shareNumbers :: [ShareNumber]
+    , allocatedSize :: Size
+    }
+    deriving (Show, Eq, Generic)
 
 instance ToJSON AllocateBuckets where
-  toJSON = genericToJSON tahoeJSONOptions
+    toJSON = genericToJSON tahoeJSONOptions
 
 instance FromJSON AllocateBuckets where
-  parseJSON = genericParseJSON tahoeJSONOptions
+    parseJSON = genericParseJSON tahoeJSONOptions
 
 data AllocationResult = AllocationResult
-  { alreadyHave       :: [ShareNumber]
-  , allocated         :: [ShareNumber]
-  } deriving (Show, Eq, Generic)
+    { alreadyHave :: [ShareNumber]
+    , allocated :: [ShareNumber]
+    }
+    deriving (Show, Eq, Generic)
 
 instance ToJSON AllocationResult where
-  toJSON = genericToJSON tahoeJSONOptions
+    toJSON = genericToJSON tahoeJSONOptions
 
 instance FromJSON AllocationResult where
-  parseJSON = genericParseJSON tahoeJSONOptions
+    parseJSON = genericParseJSON tahoeJSONOptions
 
-data ShareType =
-  Mutable
-  | Immutable
-  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+data ShareType
+    = Mutable
+    | Immutable
+    deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 data CorruptionDetails = CorruptionDetails
-  { reason            :: String
-  } deriving (Show, Eq, Generic)
+    { reason :: String
+    }
+    deriving (Show, Eq, Generic)
 
 instance ToJSON CorruptionDetails where
-  toJSON = genericToJSON tahoeJSONOptions
+    toJSON = genericToJSON tahoeJSONOptions
 
 instance FromJSON CorruptionDetails where
-  parseJSON = genericParseJSON tahoeJSONOptions
+    parseJSON = genericParseJSON tahoeJSONOptions
 
 instance FromHttpApiData ByteRanges where
-  parseHeader bs =
-    case parseByteRanges bs of
-      Nothing -> Left "parse failed"
-      Just br -> Right br
+    parseHeader bs =
+        case parseByteRanges bs of
+            Nothing -> Left "parse failed"
+            Just br -> Right br
 
 instance ToHttpApiData ByteRanges where
-  toHeader = renderByteRanges
+    toHeader = renderByteRanges
 
 type StorageAPI =
-  -- General server information
+    -- General server information
 
-  --
-  -- GET /v1/version
-  -- Retrieve information about the server version and behavior
-  "v1" :> "version" :> Get '[CBOR, JSON] Version
+    --
+    -- GET /v1/version
+    -- Retrieve information about the server version and behavior
+    "v1" :> "version" :> Get '[CBOR, JSON] Version
+        -- Immutable share interactions
 
-  -- Immutable share interactions
+        --
+        -- POST /v1/immutable/:storage_index
+        -- Initialize a new immutable storage index
+        :<|> "v1" :> "immutable" :> Capture "storage_index" StorageIndex :> ReqBody '[CBOR, JSON] AllocateBuckets :> PostCreated '[CBOR, JSON] AllocationResult
+        --
+        -- PUT /v1/immutable/:storage_index/:share_number
+        -- Write data for an immutable share to an allocated storage index
+        --
+        -- Note this accepts JSON to facilitate code generation by servant-py.  This
+        -- is total nonsense and supplying JSON here will almost certainly break.
+        -- At some point hopefully we'll fix servant-py to not need this and then
+        -- fix the signature here.
+        :<|> "v1" :> "immutable" :> Capture "storage_index" StorageIndex :> Capture "share_number" ShareNumber :> ReqBody '[OctetStream, JSON] ShareData :> Header "Content-Range" ByteRanges :> PutCreated '[CBOR, JSON] ()
+        --
+        -- POST /v1/immutable/:storage_index/:share_number/corrupt
+        -- Advise the server of a corrupt share data
+        :<|> "v1" :> "immutable" :> Capture "storage_index" StorageIndex :> Capture "share_number" ShareNumber :> "corrupt" :> ReqBody '[CBOR, JSON] CorruptionDetails :> Post '[CBOR, JSON] ()
+        --
+        -- GET /v1/immutable/storage_index/shares
+        -- Retrieve the share numbers available for a storage index
+        :<|> "v1" :> "immutable" :> Capture "storage_index" StorageIndex :> "shares" :> Get '[CBOR, JSON] [ShareNumber]
+        --
+        -- GET /v1/immutable/:storage_index?[share=s0&share=s1&...]
+        -- Read from an immutable storage index, possibly from multiple shares, possibly limited to certain ranges
+        :<|> "v1" :> "immutable" :> Capture "storage_index" StorageIndex :> QueryParams "share_number" ShareNumber :> QueryParams "offset" Offset :> QueryParams "size" Size :> Get '[CBOR, JSON] ReadResult
+        -- Mutable share interactions
 
-  --
-  -- POST /v1/immutable/:storage_index
-  -- Initialize a new immutable storage index
-  :<|> "v1" :> "immutable" :> Capture "storage_index" StorageIndex :> ReqBody '[CBOR, JSON] AllocateBuckets :> PostCreated '[CBOR, JSON] AllocationResult
-
-  --
-  -- PUT /v1/immutable/:storage_index/:share_number
-  -- Write data for an immutable share to an allocated storage index
-  --
-  -- Note this accepts JSON to facilitate code generation by servant-py.  This
-  -- is total nonsense and supplying JSON here will almost certainly break.
-  -- At some point hopefully we'll fix servant-py to not need this and then
-  -- fix the signature here.
-  :<|> "v1" :> "immutable" :> Capture "storage_index" StorageIndex :> Capture "share_number" ShareNumber :> ReqBody '[OctetStream, JSON] ShareData :> Header "Content-Range" ByteRanges :> PutCreated '[CBOR, JSON] ()
-
-  --
-  -- POST /v1/immutable/:storage_index/:share_number/corrupt
-  -- Advise the server of a corrupt share data
-  :<|> "v1" :> "immutable" :> Capture "storage_index" StorageIndex :> Capture "share_number" ShareNumber :> "corrupt" :> ReqBody '[CBOR, JSON] CorruptionDetails :> Post '[CBOR, JSON] ()
-
-  --
-  -- GET /v1/immutable/storage_index/shares
-  -- Retrieve the share numbers available for a storage index
-  :<|> "v1" :> "immutable" :> Capture "storage_index" StorageIndex :> "shares" :> Get '[CBOR, JSON] [ShareNumber]
-
-  --
-  -- GET /v1/immutable/:storage_index?[share=s0&share=s1&...]
-  -- Read from an immutable storage index, possibly from multiple shares, possibly limited to certain ranges
-  :<|> "v1" :> "immutable" :> Capture "storage_index" StorageIndex :> QueryParams "share_number" ShareNumber :> QueryParams "offset" Offset :> QueryParams "size" Size :> Get '[CBOR, JSON] ReadResult
-
-  -- Mutable share interactions
-
-  --
-  -- POST /v1/mutable/:storage_index
-  -- Initialize a new mutable storage index
-  :<|> "v1" :> "mutable" :> Capture "storage_index" StorageIndex :> ReqBody '[CBOR, JSON] AllocateBuckets :> Post '[CBOR, JSON] AllocationResult
-
-  --
-  -- POST /v1/mutable/:storage_index/read-test-write
-  -- General purpose read-test-and-write operation.
-  :<|> "v1" :> "mutable" :> Capture "storage_index" StorageIndex :> "read-test-write" :> ReqBody '[CBOR, JSON] ReadTestWriteVectors :> Post '[CBOR, JSON] ReadTestWriteResult
-
-  --
-  -- GET /v1/mutable/:storage_index
-  -- Read from a mutable storage index
-  :<|> "v1" :> "mutable" :> Capture "storage_index" StorageIndex :> QueryParams "share_number" ShareNumber :> QueryParams "offset" Offset :> QueryParams "size" Size :> Get '[CBOR, JSON] ReadResult
-
-  --
-  -- GET /v1/mutable/:storage_index/shares
-  -- Retrieve the share numbers available for a storage index
-  :<|> "v1" :> "mutable" :> Capture "storage_index" StorageIndex :> "shares" :> Get '[CBOR, JSON] [ShareNumber]
-
-  --
-  -- POST /v1/mutable/:storage_index/:share_number/corrupt
-  -- Advise the server of a corrupt share data
-  :<|> "v1" :> "mutable" :> Capture "storage_index" StorageIndex :> Capture "share_number" ShareNumber :> "corrupt" :> ReqBody '[CBOR, JSON] CorruptionDetails :> Post '[CBOR, JSON] ()
+        --
+        -- POST /v1/mutable/:storage_index
+        -- Initialize a new mutable storage index
+        :<|> "v1" :> "mutable" :> Capture "storage_index" StorageIndex :> ReqBody '[CBOR, JSON] AllocateBuckets :> Post '[CBOR, JSON] AllocationResult
+        --
+        -- POST /v1/mutable/:storage_index/read-test-write
+        -- General purpose read-test-and-write operation.
+        :<|> "v1" :> "mutable" :> Capture "storage_index" StorageIndex :> "read-test-write" :> ReqBody '[CBOR, JSON] ReadTestWriteVectors :> Post '[CBOR, JSON] ReadTestWriteResult
+        --
+        -- GET /v1/mutable/:storage_index
+        -- Read from a mutable storage index
+        :<|> "v1" :> "mutable" :> Capture "storage_index" StorageIndex :> QueryParams "share_number" ShareNumber :> QueryParams "offset" Offset :> QueryParams "size" Size :> Get '[CBOR, JSON] ReadResult
+        --
+        -- GET /v1/mutable/:storage_index/shares
+        -- Retrieve the share numbers available for a storage index
+        :<|> "v1" :> "mutable" :> Capture "storage_index" StorageIndex :> "shares" :> Get '[CBOR, JSON] [ShareNumber]
+        --
+        -- POST /v1/mutable/:storage_index/:share_number/corrupt
+        -- Advise the server of a corrupt share data
+        :<|> "v1" :> "mutable" :> Capture "storage_index" StorageIndex :> Capture "share_number" ShareNumber :> "corrupt" :> ReqBody '[CBOR, JSON] CorruptionDetails :> Post '[CBOR, JSON] ()
 
 type ReadResult = Map ShareNumber [ShareData]
 
 data ReadVectors = ReadVectors
-  { shares      :: [ShareNumber]
-  , readVectors :: [ReadVector]
-  } deriving (Show, Eq, Generic)
+    { shares :: [ShareNumber]
+    , readVectors :: [ReadVector]
+    }
+    deriving (Show, Eq, Generic)
 
 instance ToJSON ReadVectors where
-  toJSON = genericToJSON tahoeJSONOptions
+    toJSON = genericToJSON tahoeJSONOptions
 
 instance FromJSON ReadVectors where
-  parseJSON = genericParseJSON tahoeJSONOptions
+    parseJSON = genericParseJSON tahoeJSONOptions
 
 data ReadTestWriteResult = ReadTestWriteResult
-  { success  :: Bool
-  , readData :: ReadResult
-  } deriving (Show, Eq, Generic)
+    { success :: Bool
+    , readData :: ReadResult
+    }
+    deriving (Show, Eq, Generic)
 
 instance ToJSON ReadTestWriteResult where
-  toJSON = genericToJSON tahoeJSONOptions
+    toJSON = genericToJSON tahoeJSONOptions
 
 instance FromJSON ReadTestWriteResult where
-  parseJSON = genericParseJSON tahoeJSONOptions
+    parseJSON = genericParseJSON tahoeJSONOptions
 
 data ReadTestWriteVectors = ReadTestWriteVectors
-  { secrets          :: SlotSecrets
-  , testWriteVectors :: Map ShareNumber TestWriteVectors
-  , readVector       :: [ReadVector]
-  } deriving (Show, Eq, Generic)
+    { secrets :: SlotSecrets
+    , testWriteVectors :: Map ShareNumber TestWriteVectors
+    , readVector :: [ReadVector]
+    }
+    deriving (Show, Eq, Generic)
 
 instance ToJSON ReadTestWriteVectors where
-  toJSON = genericToJSON tahoeJSONOptions
+    toJSON = genericToJSON tahoeJSONOptions
 
 instance FromJSON ReadTestWriteVectors where
-  parseJSON = genericParseJSON tahoeJSONOptions
+    parseJSON = genericParseJSON tahoeJSONOptions
 
 data ReadVector = ReadVector
-  { offset     :: Offset
-  , readSize   :: Size
-  } deriving (Show, Eq, Generic)
+    { offset :: Offset
+    , readSize :: Size
+    }
+    deriving (Show, Eq, Generic)
 
 instance ToJSON ReadVector where
-  toJSON = genericToJSON tahoeJSONOptions
+    toJSON = genericToJSON tahoeJSONOptions
 
 instance FromJSON ReadVector where
-  parseJSON = genericParseJSON tahoeJSONOptions
+    parseJSON = genericParseJSON tahoeJSONOptions
 
 data TestWriteVectors = TestWriteVectors
-  { test  :: [TestVector]
-  , write :: [WriteVector]
-  } deriving (Show, Eq, Generic, ToJSON, FromJSON)
+    { test :: [TestVector]
+    , write :: [WriteVector]
+    }
+    deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
-data TestOperator =
-  Lt
-  | Le
-  | Eq
-  | Ne
-  | Ge
-  | Gt
-  deriving (Show, Eq, Generic, ToJSON, FromJSON)
+data TestOperator
+    = Lt
+    | Le
+    | Eq
+    | Ne
+    | Ge
+    | Gt
+    deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 data TestVector = TestVector
-  { testOffset :: Offset
-  , testSize   :: Size
-  , operator   :: TestOperator
-  , specimen   :: ShareData
-  } deriving (Show, Eq, Generic, ToJSON, FromJSON)
+    { testOffset :: Offset
+    , testSize :: Size
+    , operator :: TestOperator
+    , specimen :: ShareData
+    }
+    deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 data WriteVector = WriteVector
-  { writeOffset :: Offset
-  , shareData   :: ShareData
-  } deriving (Show, Eq, Generic, ToJSON, FromJSON)
+    { writeOffset :: Offset
+    , shareData :: ShareData
+    }
+    deriving (Show, Eq, Generic, ToJSON, FromJSON)
 
 data SlotSecrets = SlotSecrets
-  { writeEnabler :: WriteEnablerSecret
-  , leaseRenew   :: LeaseRenewSecret
-  , leaseCancel  :: LeaseCancelSecret
-  } deriving (Show, Eq, Generic)
+    { writeEnabler :: WriteEnablerSecret
+    , leaseRenew :: LeaseRenewSecret
+    , leaseCancel :: LeaseCancelSecret
+    }
+    deriving (Show, Eq, Generic)
 
 instance ToJSON SlotSecrets where
-  toJSON = genericToJSON tahoeJSONOptions
+    toJSON = genericToJSON tahoeJSONOptions
 
 instance FromJSON SlotSecrets where
-  parseJSON = genericParseJSON tahoeJSONOptions
-
+    parseJSON = genericParseJSON tahoeJSONOptions
 
 type WriteEnablerSecret = String
 type LeaseRenewSecret = String

--- a/src/TahoeLAFS/Storage/APIDocs.hs
+++ b/src/TahoeLAFS/Storage/APIDocs.hs
@@ -1,128 +1,132 @@
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE DataKinds #-}
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE OverloadedStrings #-}
 
 module TahoeLAFS.Storage.APIDocs where
 
-import Prelude hiding
-  ( Eq
-  )
+import Prelude hiding (
+    Eq,
+ )
 
-import Data.Bits
-  ( shiftL
-  )
+import Data.Bits (
+    shiftL,
+ )
 
-import Data.Map
-  ( Map
-  , fromList
-  )
+import Data.Map (
+    Map,
+    fromList,
+ )
 
-import Servant
-  ( Capture(..)
-  , QueryParams
-  , Optional
-  )
+import Servant (
+    Capture (..),
+    Optional,
+    QueryParams,
+ )
 
-import Servant.Docs
-  ( ToCapture(toCapture)
-  , ToSample(toSamples)
-  , ToParam(toParam)
-  , DocCapture(DocCapture)
-  , DocQueryParam(DocQueryParam)
-  , ParamKind(Normal, List)
-  , singleSample
-  , samples
-  )
+import Servant.Docs (
+    DocCapture (DocCapture),
+    DocQueryParam (DocQueryParam),
+    ParamKind (List, Normal),
+    ToCapture (toCapture),
+    ToParam (toParam),
+    ToSample (toSamples),
+    samples,
+    singleSample,
+ )
 
-import TahoeLAFS.Storage.API
-  ( StorageIndex
-  , ShareNumber(ShareNumber)
-  , Offset
-  , ReadResult
-  , Version(Version)
-  , ApplicationVersion
-  , Version1Parameters(Version1Parameters)
-  , AllocateBuckets(AllocateBuckets)
-  , AllocationResult(AllocationResult)
-  , CorruptionDetails(CorruptionDetails)
-  , ReadTestWriteVectors(ReadTestWriteVectors)
-  , ShareData
-  , SlotSecrets(SlotSecrets)
-  , ReadTestWriteResult(ReadTestWriteResult)
-  , TestWriteVectors(TestWriteVectors)
-  , ReadVector
-  , TestVector(TestVector)
-  , WriteVector(WriteVector)
-  , TestOperator(Eq)
-  , renewSecretLength
-  , writeEnablerSecretLength
-  , leaseRenewSecretLength
-  , leaseCancelSecretLength
-  )
+import TahoeLAFS.Storage.API (
+    AllocateBuckets (AllocateBuckets),
+    AllocationResult (AllocationResult),
+    ApplicationVersion,
+    CorruptionDetails (CorruptionDetails),
+    Offset,
+    ReadResult,
+    ReadTestWriteResult (ReadTestWriteResult),
+    ReadTestWriteVectors (ReadTestWriteVectors),
+    ReadVector,
+    ShareData,
+    ShareNumber (ShareNumber),
+    SlotSecrets (SlotSecrets),
+    StorageIndex,
+    TestOperator (Eq),
+    TestVector (TestVector),
+    TestWriteVectors (TestWriteVectors),
+    Version (Version),
+    Version1Parameters (Version1Parameters),
+    WriteVector (WriteVector),
+    leaseCancelSecretLength,
+    leaseRenewSecretLength,
+    renewSecretLength,
+    writeEnablerSecretLength,
+ )
 
 instance ToCapture (Capture "storage_index" StorageIndex) where
-  toCapture _ = DocCapture "storage index" "(hex string) a storage index to use to address the data"
+    toCapture _ = DocCapture "storage index" "(hex string) a storage index to use to address the data"
 
 instance ToCapture (Capture "share_number" ShareNumber) where
-  toCapture _ = DocCapture "share number" "(integer) a share number to use to address a particular share"
+    toCapture _ = DocCapture "share number" "(integer) a share number to use to address a particular share"
 
 instance ToParam (QueryParams "share_number" ShareNumber) where
-  toParam _ = DocQueryParam "share_number" [] "(integer) a share number to use to address a particular share" List
+    toParam _ = DocQueryParam "share_number" [] "(integer) a share number to use to address a particular share" List
 
 instance ToParam (QueryParams "offset" Integer) where
-  toParam _ = DocQueryParam "offset" [] "(integer) offset into a share to read or write" List
+    toParam _ = DocQueryParam "offset" [] "(integer) offset into a share to read or write" List
 
 instance ToParam (QueryParams "size" Integer) where
-  toParam _ = DocQueryParam "size" [] "(integer) number of bytes of a share to read" List
+    toParam _ = DocQueryParam "size" [] "(integer) number of bytes of a share to read" List
 
 instance ToSample ReadResult where
-  toSamples _ = singleSample mempty
+    toSamples _ = singleSample mempty
 
 instance ToSample Version where
-  toSamples _ = singleSample $
-    Version "blub version??" (Version1Parameters (1 `shiftL` 16) (2 `shiftL` 32) (2 `shiftL` 64) True True True True True)
+    toSamples _ =
+        singleSample $
+            Version "blub version??" (Version1Parameters (1 `shiftL` 16) (2 `shiftL` 32) (2 `shiftL` 64) True True True True True)
 
 instance ToSample AllocateBuckets where
-  toSamples _ =
-    singleSample (
-    AllocateBuckets
-      (example renewSecretLength "a")
-      (example renewSecretLength "b")
-      [ShareNumber 1, ShareNumber 3]
-      1024
-    )
+    toSamples _ =
+        singleSample
+            ( AllocateBuckets
+                (example renewSecretLength "a")
+                (example renewSecretLength "b")
+                [ShareNumber 1, ShareNumber 3]
+                1024
+            )
 
 instance ToSample AllocationResult where
-  toSamples _ =
-    singleSample $ AllocationResult [ShareNumber 1] [ShareNumber 3]
+    toSamples _ =
+        singleSample $ AllocationResult [ShareNumber 1] [ShareNumber 3]
 
 instance ToSample ShareData where
-  toSamples _ =
-    singleSample "abcdefgh"
+    toSamples _ =
+        singleSample "abcdefgh"
 
 instance ToSample () where
-  toSamples _ = singleSample ()
+    toSamples _ = singleSample ()
 
 instance ToSample CorruptionDetails where
-  toSamples _ = singleSample $ CorruptionDetails "sha256 mismatch maybe?"
+    toSamples _ = singleSample $ CorruptionDetails "sha256 mismatch maybe?"
 
 instance ToSample ShareNumber where
-  toSamples _ = samples [ShareNumber 0, ShareNumber 3]
+    toSamples _ = samples [ShareNumber 0, ShareNumber 3]
 
 instance ToSample ReadTestWriteVectors where
-  toSamples _ = singleSample $
-    ReadTestWriteVectors
-    (SlotSecrets (example writeEnablerSecretLength "c") (example leaseRenewSecretLength "d") (example leaseCancelSecretLength "e"))
-    sampleTestWriteVectors
-    sampleReadVector
+    toSamples _ =
+        singleSample $
+            ReadTestWriteVectors
+                (SlotSecrets (example writeEnablerSecretLength "c") (example leaseRenewSecretLength "d") (example leaseCancelSecretLength "e"))
+                sampleTestWriteVectors
+                sampleReadVector
 
 instance ToSample ReadTestWriteResult where
-  toSamples _ = singleSample $
-    ReadTestWriteResult True sampleReadResult
+    toSamples _ =
+        singleSample $
+            ReadTestWriteResult True sampleReadResult
 
 sampleTestWriteVectors :: Map ShareNumber TestWriteVectors
-sampleTestWriteVectors = fromList
-  [ (ShareNumber 0, TestWriteVectors [ TestVector 32 33 Eq "x" ] [ WriteVector 32 "y" ] ) ]
+sampleTestWriteVectors =
+    fromList
+        [(ShareNumber 0, TestWriteVectors [TestVector 32 33 Eq "x"] [WriteVector 32 "y"])]
 
 sampleReadVector :: [ReadVector]
 sampleReadVector = mempty
@@ -130,4 +134,5 @@ sampleReadVector = mempty
 sampleReadResult :: ReadResult
 sampleReadResult = mempty
 
+example :: Int -> [a] -> [a]
 example n s = concat $ replicate n s

--- a/src/TahoeLAFS/Storage/Backend.hs
+++ b/src/TahoeLAFS/Storage/Backend.hs
@@ -1,107 +1,107 @@
+module TahoeLAFS.Storage.Backend (
+    Backend (..),
+    ImmutableShareAlreadyWritten (ImmutableShareAlreadyWritten),
+    writeMutableShare,
+) where
 
-module TahoeLAFS.Storage.Backend
-  ( Backend(..)
-  , ImmutableShareAlreadyWritten(ImmutableShareAlreadyWritten)
-  , writeMutableShare
-  ) where
+import Control.Exception (
+    Exception,
+    throw,
+ )
 
-import Control.Exception
-  ( Exception
-  , throw
-  )
+import Data.Map.Strict (
+    fromList,
+ )
 
-import Data.Map.Strict
-  ( fromList
-  )
+import Network.HTTP.Types (
+    ByteRanges,
+ )
 
-import Network.HTTP.Types
-  ( ByteRanges
-  )
-
-import TahoeLAFS.Storage.API
-  ( Version
-  , StorageIndex
-  , AllocateBuckets
-  , AllocationResult
-  , SlotSecrets(SlotSecrets)
-  , ShareNumber
-  , Size
-  , Offset
-  , ReadResult
-  , TestWriteVectors(..)
-  , WriteVector(..)
-  , ReadTestWriteVectors(..)
-  , ReadTestWriteResult(..)
-  , CorruptionDetails
-  , ShareData
-
-  )
+import TahoeLAFS.Storage.API (
+    AllocateBuckets,
+    AllocationResult,
+    CorruptionDetails,
+    Offset,
+    ReadResult,
+    ReadTestWriteResult (..),
+    ReadTestWriteVectors (..),
+    ShareData,
+    ShareNumber,
+    Size,
+    SlotSecrets,
+    StorageIndex,
+    TestWriteVectors (..),
+    Version,
+    WriteVector (..),
+ )
 
 data ImmutableShareAlreadyWritten = ImmutableShareAlreadyWritten
-  deriving (Show)
+    deriving (Show)
 instance Exception ImmutableShareAlreadyWritten
 
 class Backend b where
-  version :: b -> IO Version
+    version :: b -> IO Version
 
-  createImmutableStorageIndex :: b -> StorageIndex -> AllocateBuckets -> IO AllocationResult
+    createImmutableStorageIndex :: b -> StorageIndex -> AllocateBuckets -> IO AllocationResult
 
-  -- May throw ImmutableShareAlreadyWritten
-  writeImmutableShare :: b -> StorageIndex -> ShareNumber -> ShareData -> Maybe ByteRanges -> IO ()
-  adviseCorruptImmutableShare :: b -> StorageIndex -> ShareNumber -> CorruptionDetails -> IO ()
-  getImmutableShareNumbers :: b -> StorageIndex -> IO [ShareNumber]
+    -- May throw ImmutableShareAlreadyWritten
+    writeImmutableShare :: b -> StorageIndex -> ShareNumber -> ShareData -> Maybe ByteRanges -> IO ()
+    adviseCorruptImmutableShare :: b -> StorageIndex -> ShareNumber -> CorruptionDetails -> IO ()
+    getImmutableShareNumbers :: b -> StorageIndex -> IO [ShareNumber]
 
-  readImmutableShares :: b -> StorageIndex -> [ShareNumber] -> [Offset] -> [Size] -> IO ReadResult
+    -- Provide a default for requesting all shares.
+    readImmutableShares :: b -> StorageIndex -> [ShareNumber] -> [Offset] -> [Size] -> IO ReadResult
+    readImmutableShares backend storageIndex [] offsets sizes = do
+        shareNumbers <- getImmutableShareNumbers backend storageIndex
+        case shareNumbers of
+            [] ->
+                return mempty
+            _ ->
+                readImmutableShares backend storageIndex shareNumbers offsets sizes
+    readImmutableShares _ _ _ _ _ = error "readImmutableShares got bad input"
 
-  -- Provide a default for requesting all shares.
-  readImmutableShares backend storageIndex [] offsets sizes = do
-    shareNumbers <- getImmutableShareNumbers backend storageIndex
-    case shareNumbers of
-      [] ->
-        return mempty
-      _  ->
-        readImmutableShares backend storageIndex shareNumbers offsets sizes
+    createMutableStorageIndex :: b -> StorageIndex -> AllocateBuckets -> IO AllocationResult
+    readvAndTestvAndWritev :: b -> StorageIndex -> ReadTestWriteVectors -> IO ReadTestWriteResult
+    readMutableShares :: b -> StorageIndex -> [ShareNumber] -> [Offset] -> [Size] -> IO ReadResult
+    getMutableShareNumbers :: b -> StorageIndex -> IO [ShareNumber]
+    adviseCorruptMutableShare :: b -> StorageIndex -> ShareNumber -> CorruptionDetails -> IO ()
 
-  createMutableStorageIndex :: b -> StorageIndex -> AllocateBuckets -> IO AllocationResult
-  readvAndTestvAndWritev :: b -> StorageIndex -> ReadTestWriteVectors -> IO ReadTestWriteResult
-  readMutableShares :: b -> StorageIndex -> [ShareNumber] -> [Offset] -> [Size] -> IO ReadResult
-  getMutableShareNumbers :: b -> StorageIndex -> IO [ShareNumber]
-  adviseCorruptMutableShare :: b -> StorageIndex -> ShareNumber -> CorruptionDetails -> IO ()
-
-
-writeMutableShare
-  :: Backend b
-  => b
-  -> SlotSecrets
-  -> StorageIndex
-  -> ShareNumber
-  -> ShareData
-  -> Maybe ByteRanges
-  -> IO ()
+writeMutableShare ::
+    Backend b =>
+    b ->
+    SlotSecrets ->
+    StorageIndex ->
+    ShareNumber ->
+    ShareData ->
+    Maybe ByteRanges ->
+    IO ()
 writeMutableShare b secrets storageIndex shareNumber shareData Nothing = do
-  let testWriteVectors =
-        fromList
-        [( shareNumber
-         , TestWriteVectors
-           { test = []
-           , write =
-               [WriteVector
-                 { writeOffset = 0
-                 , shareData = shareData
-                 }
-               ]
-           }
-         )]
-  let vectors = ReadTestWriteVectors
+    let testWriteVectors =
+            fromList
+                [
+                    ( shareNumber
+                    , TestWriteVectors
+                        { test = []
+                        , write =
+                            [ WriteVector
+                                { writeOffset = 0
+                                , shareData = shareData
+                                }
+                            ]
+                        }
+                    )
+                ]
+    let vectors =
+            ReadTestWriteVectors
                 { secrets = secrets
                 , testWriteVectors = testWriteVectors
                 , readVector = mempty
                 }
-  result <- readvAndTestvAndWritev b storageIndex vectors
-  if success result then
-    return ()
-    else
-    throw WriteRefused
+    result <- readvAndTestvAndWritev b storageIndex vectors
+    if success result
+        then return ()
+        else throw WriteRefused
+writeMutableShare _ _ _ _ _ _ = error "writeMutableShare got bad input"
 
 data WriteRefused = WriteRefused deriving (Show, Eq)
 instance Exception WriteRefused

--- a/src/TahoeLAFS/Storage/Backend/Filesystem.hs
+++ b/src/TahoeLAFS/Storage/Backend/Filesystem.hs
@@ -1,105 +1,101 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module TahoeLAFS.Storage.Backend.Filesystem
-  ( FilesystemBackend(FilesystemBackend)
-  , storageStartSegment
-  , partitionM
-  , pathOfShare
-  , incomingPathOf
-  ) where
+module TahoeLAFS.Storage.Backend.Filesystem (
+    FilesystemBackend (FilesystemBackend),
+    storageStartSegment,
+    partitionM,
+    pathOfShare,
+    incomingPathOf,
+) where
 
-import Prelude hiding
-  ( writeFile
-  , readFile
-  )
+import Prelude hiding (
+    readFile,
+    writeFile,
+ )
 
-import Text.Printf
-  ( printf
-  )
+import Network.HTTP.Types (
+    ByteRanges,
+ )
 
-import Data.ByteString
-  ( writeFile
-  , readFile
-  , hPut
-  )
+import Data.ByteString (
+    hPut,
+    readFile,
+    writeFile,
+ )
 
-import Control.Exception
-  ( tryJust
-  , throwIO
-  )
+import Control.Exception (
+    throwIO,
+    tryJust,
+ )
 
-import Data.Maybe
-  ( mapMaybe
-  )
+import Data.Maybe (
+    mapMaybe,
+ )
 
-import Data.List
-  ( partition
-  )
+import Data.Map.Strict (
+    fromList,
+    toList,
+ )
 
-import Data.Map.Strict
-  ( fromList
-  , toList
-  )
+import System.IO (
+    Handle,
+    IOMode (ReadWriteMode),
+    SeekMode (AbsoluteSeek),
+    hSeek,
+    withBinaryFile,
+ )
+import System.IO.Error (
+    isDoesNotExistError,
+ )
 
-import System.IO
-  ( Handle
-  , IOMode(ReadWriteMode)
-  , SeekMode(AbsoluteSeek)
-  , withBinaryFile
-  , hSeek
-  )
-import System.IO.Error
-  ( isDoesNotExistError
-  )
+import System.FilePath (
+    takeDirectory,
+    (</>),
+ )
 
-import System.FilePath
-  ( FilePath
-  , takeDirectory
-  , (</>)
-  )
-import System.Posix.StatVFS
-  ( StatVFS(statVFS_bsize, statVFS_bavail)
-  , statVFS
-  )
+import System.Posix.StatVFS (
+    StatVFS (statVFS_bavail, statVFS_bsize),
+    statVFS,
+ )
 
-import System.Directory
-  ( doesPathExist
-  , createDirectoryIfMissing
-  , renameFile
-  , listDirectory
-  )
+import System.Directory (
+    createDirectoryIfMissing,
+    doesPathExist,
+    listDirectory,
+    renameFile,
+ )
 
-import TahoeLAFS.Storage.API
-  ( Version(..)
-  , Size
-  , Offset
-  , StorageIndex
-  , ShareNumber
-  , ShareData
-  , WriteVector(WriteVector)
-  , TestWriteVectors(write)
-  , ReadTestWriteVectors(ReadTestWriteVectors)
-  , ReadTestWriteResult(ReadTestWriteResult, success, readData)
-  , ApplicationVersion(..)
-  , Version1Parameters(..)
-  , AllocateBuckets(..)
-  , AllocationResult(..)
-  , shareNumber
-  )
+import TahoeLAFS.Storage.API (
+    AllocateBuckets (..),
+    AllocationResult (..),
+    Offset,
+    ReadTestWriteResult (ReadTestWriteResult, readData, success),
+    ReadTestWriteVectors (ReadTestWriteVectors),
+    ShareData,
+    ShareNumber,
+    StorageIndex,
+    TestWriteVectors (write),
+    Version (..),
+    Version1Parameters (..),
+    WriteVector (WriteVector),
+    shareNumber,
+ )
 
 import qualified TahoeLAFS.Storage.API as Storage
 
-import TahoeLAFS.Storage.Backend
-  ( ImmutableShareAlreadyWritten(ImmutableShareAlreadyWritten)
-  , Backend(..)
-  )
+import TahoeLAFS.Storage.Backend (
+    Backend (..),
+    ImmutableShareAlreadyWritten (ImmutableShareAlreadyWritten),
+ )
 
 data FilesystemBackend = FilesystemBackend FilePath
-  deriving (Show)
+    deriving (Show)
 
+versionString :: Storage.ApplicationVersion
 versionString = "tahoe-lafs (gbs) 0.1.0"
 
 -- Copied from the Python implementation.  Kind of arbitrary.
+maxMutableShareSize :: Storage.Size
 maxMutableShareSize = 69105 * 1000 * 1000 * 1000 * 1000
 
 --  storage/
@@ -113,189 +109,189 @@ maxMutableShareSize = 69105 * 1000 * 1000 * 1000 * 1000
 --  base-32 chars).
 
 instance Backend FilesystemBackend where
-  version (FilesystemBackend path) = do
-    vfs <- statVFS path
-    let available = toInteger (statVFS_bsize vfs) * toInteger (statVFS_bavail vfs)
-    return Version
-      { applicationVersion = versionString
-      , parameters =
-          Version1Parameters
-          { maximumImmutableShareSize = available
-          , maximumMutableShareSize = maxMutableShareSize
-          -- TODO: Copy the "reserved space" feature of the Python
-          -- implementation.
-          , availableSpace = available
-          , toleratesImmutableReadOverrun = True
-          , deleteMutableSharesWithZeroLengthWritev = True
-          , fillsHolesWithZeroBytes = True
-          , preventsReadPastEndOfShareData = True
-          -- TODO Doesn't really belong here.  Also we need more than a bool.
-          -- We need to tell them *where* it is available or it is useless.
-          , httpProtocolAvailable = True
-          }
-      }
+    version (FilesystemBackend path) = do
+        vfs <- statVFS path
+        let available = toInteger (statVFS_bsize vfs) * toInteger (statVFS_bavail vfs)
+        return
+            Version
+                { applicationVersion = versionString
+                , parameters =
+                    Version1Parameters
+                        { maximumImmutableShareSize = available
+                        , maximumMutableShareSize = maxMutableShareSize
+                        , -- TODO: Copy the "reserved space" feature of the Python
+                          -- implementation.
+                          availableSpace = available
+                        , toleratesImmutableReadOverrun = True
+                        , deleteMutableSharesWithZeroLengthWritev = True
+                        , fillsHolesWithZeroBytes = True
+                        , preventsReadPastEndOfShareData = True
+                        , -- TODO Doesn't really belong here.  Also we need more than a bool.
+                          -- We need to tell them *where* it is available or it is useless.
+                          httpProtocolAvailable = True
+                        }
+                }
 
-  createImmutableStorageIndex backend storageIndex params = do
-    let exists = haveShare backend storageIndex
-    (alreadyHave, allocated) <- partitionM exists (shareNumbers params)
-    allocatev backend storageIndex allocated
-    return AllocationResult
-      { alreadyHave = alreadyHave
-      , allocated = allocated
-      }
+    createImmutableStorageIndex :: FilesystemBackend -> StorageIndex -> AllocateBuckets -> IO AllocationResult
+    createImmutableStorageIndex backend storageIndex params = do
+        let exists = haveShare backend storageIndex
+        (alreadyHave, allocated) <- partitionM exists (shareNumbers params)
+        allocatev backend storageIndex allocated
+        return
+            AllocationResult
+                { alreadyHave = alreadyHave
+                , allocated = allocated
+                }
 
-  -- TODO Handle ranges.
-  -- TODO Make sure the share storage was allocated.
-  -- TODO Don't allow target of rename to exist.
-  -- TODO Concurrency
-  writeImmutableShare (FilesystemBackend root) storageIndex shareNumber shareData Nothing = do
-    alreadyHave <- haveShare (FilesystemBackend root) storageIndex shareNumber
-    if alreadyHave
-      then throwIO ImmutableShareAlreadyWritten
-      else
-      do
-        let finalSharePath = pathOfShare root storageIndex shareNumber
-        let incomingSharePath = incomingPathOf root storageIndex shareNumber
-        writeFile incomingSharePath shareData
-        let createParents = True
-        createDirectoryIfMissing createParents $ takeDirectory finalSharePath
-        renameFile incomingSharePath finalSharePath
+    -- TODO Handle ranges.
+    -- TODO Make sure the share storage was allocated.
+    -- TODO Don't allow target of rename to exist.
+    -- TODO Concurrency
+    writeImmutableShare :: FilesystemBackend -> StorageIndex -> ShareNumber -> ShareData -> Maybe ByteRanges -> IO ()
+    writeImmutableShare (FilesystemBackend root) storageIndex shareNumber' shareData Nothing = do
+        alreadyHave <- haveShare (FilesystemBackend root) storageIndex shareNumber'
+        if alreadyHave
+            then throwIO ImmutableShareAlreadyWritten
+            else do
+                let finalSharePath = pathOfShare root storageIndex shareNumber'
+                let incomingSharePath = incomingPathOf root storageIndex shareNumber'
+                writeFile incomingSharePath shareData
+                let createParents = True
+                createDirectoryIfMissing createParents $ takeDirectory finalSharePath
+                renameFile incomingSharePath finalSharePath
 
-  getImmutableShareNumbers (FilesystemBackend root) storageIndex = do
-    let storageIndexPath = pathOfStorageIndex root storageIndex
-    storageIndexChildren <-
-      tryJust (Just . isDoesNotExistError) $ listDirectory storageIndexPath
-    let sharePaths =
-          case storageIndexChildren of
-            Left _           -> []
-            Right children   -> children
-    return $ mapMaybe (shareNumber . read) sharePaths
+    getImmutableShareNumbers :: FilesystemBackend -> StorageIndex -> IO [ShareNumber]
+    getImmutableShareNumbers (FilesystemBackend root) storageIndex = do
+        let storageIndexPath = pathOfStorageIndex root storageIndex
+        storageIndexChildren <-
+            tryJust (Just . isDoesNotExistError) $ listDirectory storageIndexPath
+        let sharePaths =
+                case storageIndexChildren of
+                    Left _ -> []
+                    Right children -> children
+        return $ mapMaybe (shareNumber . read) sharePaths
 
-  -- TODO Handle ranges.
-  -- TODO Make sure the share storage was allocated.
-  readImmutableShares (FilesystemBackend root) storageIndex shareNumbers [] [] =
-    let storageIndexPath = pathOfStorageIndex root storageIndex
-        only x = [x]
-        readShare = readFile . pathOfShare root storageIndex
-    in
-      fromList . zip shareNumbers . map only <$> mapM readShare shareNumbers
+    -- TODO Handle ranges.
+    -- TODO Make sure the share storage was allocated.
+    readImmutableShares :: FilesystemBackend -> StorageIndex -> [ShareNumber] -> [Offset] -> [Storage.Size] -> IO Storage.ReadResult
+    readImmutableShares (FilesystemBackend root) storageIndex shareNumbers [] [] =
+        let _storageIndexPath = pathOfStorageIndex root storageIndex
+            only x = [x]
+            readShare = readFile . pathOfShare root storageIndex
+         in fromList . zip shareNumbers . map only <$> mapM readShare shareNumbers
+    readImmutableShares _ _ _ _ _ = error "readImmutableShares got bad input"
 
-  createMutableStorageIndex = createImmutableStorageIndex
+    createMutableStorageIndex = createImmutableStorageIndex
 
-  getMutableShareNumbers = getImmutableShareNumbers
+    getMutableShareNumbers = getImmutableShareNumbers
 
-  readvAndTestvAndWritev
-    (FilesystemBackend root)
-    storageIndex
-    (ReadTestWriteVectors secrets testWritev readv) = do
-    -- TODO implement readv and testv parts.  implement secrets part.
-    mapM_ (applyWriteVectors root storageIndex) $ toList testWritev
-    return ReadTestWriteResult
-      { success = True
-      , readData = mempty
-      }
+    readvAndTestvAndWritev
+        (FilesystemBackend root)
+        storageIndex
+        (ReadTestWriteVectors _secrets testWritev _readv) = do
+            -- TODO implement readv and testv parts.  implement secrets part.
+            mapM_ (applyWriteVectors root storageIndex) $ toList testWritev
+            return
+                ReadTestWriteResult
+                    { success = True
+                    , readData = mempty
+                    }
+          where
+            applyWriteVectors ::
+                FilePath ->
+                StorageIndex ->
+                (ShareNumber, TestWriteVectors) ->
+                IO ()
+            applyWriteVectors _root _storageIndex (shareNumber', testWriteVectors) =
+                mapM_ (applyShareWrite root storageIndex shareNumber') (write testWriteVectors)
 
-    where
-      applyWriteVectors
-        :: FilePath
-        -> StorageIndex
-        -> (ShareNumber, TestWriteVectors)
-        -> IO ()
-      applyWriteVectors root storageIndex (shareNumber, testWriteVectors) =
-        mapM_ (applyShareWrite root storageIndex shareNumber) (write testWriteVectors)
-
-      applyShareWrite
-        :: FilePath
-        -> StorageIndex
-        -> ShareNumber
-        -> WriteVector
-        -> IO ()
-      applyShareWrite root storageIndex shareNumber (WriteVector offset shareData) =
-        let sharePath = pathOfShare root storageIndex shareNumber
-            createParents = True
-        in
-          do
-            createDirectoryIfMissing createParents $ takeDirectory sharePath
-            withBinaryFile sharePath ReadWriteMode (writeAtPosition offset shareData)
-        where
-          writeAtPosition
-            :: Offset
-            -> ShareData
-            -> Handle
-            -> IO ()
-          writeAtPosition offset shareData handle = do
-            hSeek handle AbsoluteSeek offset
-            hPut handle shareData
-
-
+            applyShareWrite ::
+                FilePath ->
+                StorageIndex ->
+                ShareNumber ->
+                WriteVector ->
+                IO ()
+            applyShareWrite _root _storageIndex shareNumber' (WriteVector offset shareData) =
+                let sharePath = pathOfShare root storageIndex shareNumber'
+                    createParents = True
+                 in do
+                        createDirectoryIfMissing createParents $ takeDirectory sharePath
+                        withBinaryFile sharePath ReadWriteMode (writeAtPosition offset shareData)
+              where
+                writeAtPosition ::
+                    Offset ->
+                    ShareData ->
+                    Handle ->
+                    IO ()
+                writeAtPosition _offset shareData' handle = do
+                    hSeek handle AbsoluteSeek offset
+                    hPut handle shareData'
 
 -- Does the given backend have the complete share indicated?
-haveShare
-  :: FilesystemBackend -- The backend to check
-  -> StorageIndex      -- The storage index the share belongs to
-  -> ShareNumber       -- The number of the share
-  -> IO Bool           -- True if it has the share, False otherwise.
-haveShare (FilesystemBackend path) storageIndex shareNumber =
-  doesPathExist $ pathOfShare path storageIndex shareNumber
+haveShare ::
+    FilesystemBackend -> -- The backend to check
+    StorageIndex -> -- The storage index the share belongs to
+    ShareNumber -> -- The number of the share
+    IO Bool -- True if it has the share, False otherwise.
+haveShare (FilesystemBackend path) storageIndex shareNumber' =
+    doesPathExist $ pathOfShare path storageIndex shareNumber'
 
-pathOfStorageIndex
-  :: FilePath      -- The storage backend root path
-  -> StorageIndex  -- The storage index to consider
-  -> FilePath      -- The path to the directory containing shares for the
-                   -- storage index.
+pathOfStorageIndex ::
+    FilePath -> -- The storage backend root path
+    StorageIndex -> -- The storage index to consider
+    FilePath -- The path to the directory containing shares for the
+    -- storage index.
 pathOfStorageIndex root storageIndex =
-  root </> "shares" </> storageStartSegment storageIndex </> storageIndex
+    root </> "shares" </> storageStartSegment storageIndex </> storageIndex
 
 pathOfShare :: FilePath -> StorageIndex -> ShareNumber -> FilePath
-pathOfShare root storageIndex shareNumber =
-  pathOfStorageIndex root storageIndex </> show (Storage.toInteger shareNumber)
+pathOfShare root storageIndex shareNumber' =
+    pathOfStorageIndex root storageIndex </> show (Storage.toInteger shareNumber')
 
 incomingPathOf :: FilePath -> StorageIndex -> ShareNumber -> FilePath
-incomingPathOf root storageIndex shareNumber =
-  root </> "shares" </> "incoming" </> storageStartSegment storageIndex </> storageIndex </> show (Storage.toInteger shareNumber)
+incomingPathOf root storageIndex shareNumber' =
+    root </> "shares" </> "incoming" </> storageStartSegment storageIndex </> storageIndex </> show (Storage.toInteger shareNumber')
 
 storageStartSegment :: StorageIndex -> FilePath
 storageStartSegment [] = fail "illegal short storage index"
-storageStartSegment [a] = storageStartSegment []
-storageStartSegment (a:b:rest) = [a, b]
+storageStartSegment [_] = storageStartSegment []
+storageStartSegment (a : b : _) = [a, b]
 
 -- Create a space to write data for an incoming share.
-allocate
-  :: FilesystemBackend
-  -> StorageIndex
-  -> ShareNumber
-  -> IO ()
-allocate backend storageIndex shareNumber =
-  allocatev backend storageIndex [shareNumber]
+allocate ::
+    FilesystemBackend ->
+    StorageIndex ->
+    ShareNumber ->
+    IO ()
+allocate backend storageIndex shareNumber' =
+    allocatev backend storageIndex [shareNumber']
 
 -- Create spaces to write data for several incoming shares.
-allocatev
-  :: FilesystemBackend
-  -> StorageIndex
-  -> [ShareNumber]
-  -> IO ()
-allocatev backend storageIndex [] = return ()
-allocatev (FilesystemBackend root) storageIndex (shareNumber:rest) =
-  let sharePath = incomingPathOf root storageIndex shareNumber
-      shareDirectory = takeDirectory sharePath
-      createParents = True
-  in
-    do
-      createDirectoryIfMissing createParents shareDirectory
-      writeFile sharePath ""
-      allocatev (FilesystemBackend root) storageIndex rest
-      return ()
+allocatev ::
+    FilesystemBackend ->
+    StorageIndex ->
+    [ShareNumber] ->
+    IO ()
+allocatev _backend _storageIndex [] = return ()
+allocatev (FilesystemBackend root) storageIndex (shareNumber : rest) =
+    let sharePath = incomingPathOf root storageIndex shareNumber
+        shareDirectory = takeDirectory sharePath
+        createParents = True
+     in do
+            createDirectoryIfMissing createParents shareDirectory
+            writeFile sharePath ""
+            allocatev (FilesystemBackend root) storageIndex rest
+            return ()
 
 partitionM :: Monad m => (a -> m Bool) -> [a] -> m ([a], [a])
-partitionM pred items = do
-  (yes, no) <- partitionM' pred items [] []
-  -- re-reverse them to maintain input order
-  return (reverse yes, reverse no)
+partitionM pred' items = do
+    (yes, no) <- partitionM' pred' items [] []
+    -- re-reverse them to maintain input order
+    return (reverse yes, reverse no)
   where
-    partitionM' pred [] yes no = return (yes, no)
-    partitionM' pred (item:rest) yes no = do
-      result <- pred item
-      if result then
-        partitionM' pred rest (item:yes) no
-        else
-        partitionM' pred rest yes (item:no)
+    partitionM' _ [] yes no = return (yes, no)
+    partitionM' pred'' (item : rest) yes no = do
+        result <- pred'' item
+        if result
+            then partitionM' pred'' rest (item : yes) no
+            else partitionM' pred'' rest yes (item : no)

--- a/src/TahoeLAFS/Storage/Backend/Memory.hs
+++ b/src/TahoeLAFS/Storage/Backend/Memory.hs
@@ -1,193 +1,209 @@
-module TahoeLAFS.Storage.Backend.Memory
-  ( MemoryBackend(MemoryBackend)
-  , memoryBackend
-  ) where
+module TahoeLAFS.Storage.Backend.Memory (
+    MemoryBackend (MemoryBackend),
+    memoryBackend,
+) where
 
-import Prelude hiding
-  ( map
-  , lookup
-  )
-
-import Control.Exception
-  ( throwIO
-  )
-
-import Data.IORef
- ( IORef
- , newIORef
- , readIORef
- , modifyIORef
- , atomicModifyIORef'
+import Prelude hiding (
+    lookup,
+    map,
  )
 
-import Data.Map.Strict
-  ( Map
-  , map
-  , keys
-  , lookup
-  , alter
-  , member
-  , insert
-  , adjust
-  , fromList
-  , toList
-  , filterWithKey
-  )
+import Network.HTTP.Types (
+    ByteRanges,
+ )
 
-import System.Posix.StatVFS
-  ( StatVFS(statVFS_bsize, statVFS_bavail)
-  , statVFS
-  )
+import Control.Exception (
+    throwIO,
+ )
 
-import TahoeLAFS.Storage.API
-  ( Version(..)
-  , Size
-  , Offset
-  , StorageIndex
-  , ShareNumber
-  , ShareData
-  , ApplicationVersion(..)
-  , Version1Parameters(..)
-  , AllocationResult(..)
-  , ReadTestWriteVectors(..)
-  , ReadTestWriteResult(..)
-  , TestWriteVectors(..)
-  , WriteVector(..)
-  , shareNumbers
-  )
+import Data.IORef (
+    IORef,
+    atomicModifyIORef',
+    modifyIORef,
+    newIORef,
+    readIORef,
+ )
 
-import TahoeLAFS.Storage.Backend
-  ( Backend(..)
-  , ImmutableShareAlreadyWritten(ImmutableShareAlreadyWritten)
-  )
+import Data.Map.Strict (
+    Map,
+    adjust,
+    filterWithKey,
+    fromList,
+    insert,
+    keys,
+    lookup,
+    map,
+    toList,
+ )
+
+-- import System.Posix.StatVFS
+--   ( StatVFS(statVFS_bsize, statVFS_bavail)
+--   , statVFS
+--   )
+
+import TahoeLAFS.Storage.API (
+    AllocateBuckets,
+    AllocationResult (..),
+    CorruptionDetails,
+    Offset,
+    ReadResult,
+    ReadTestWriteResult (..),
+    ReadTestWriteVectors (..),
+    ShareData,
+    ShareNumber,
+    Size,
+    StorageIndex,
+    TestWriteVectors (..),
+    Version (..),
+    Version1Parameters (..),
+    WriteVector (..),
+    shareNumbers,
+ )
+
+import TahoeLAFS.Storage.Backend (
+    Backend (..),
+    ImmutableShareAlreadyWritten (ImmutableShareAlreadyWritten),
+ )
 
 type ShareStorage = Map StorageIndex (Map ShareNumber ShareData)
 type BucketStorage = Map StorageIndex (Map ShareNumber (Size, ShareData))
 
 data MemoryBackend = MemoryBackend
-  { immutableShares :: IORef ShareStorage -- Completely written immutable shares
-  , mutableShares :: IORef ShareStorage -- Completely written mutable shares
-  , buckets :: IORef BucketStorage -- In-progress immutable share uploads
-  }
+    { immutableShares :: IORef ShareStorage -- Completely written immutable shares
+    , mutableShares :: IORef ShareStorage -- Completely written mutable shares
+    , buckets :: IORef BucketStorage -- In-progress immutable share uploads
+    }
 
 instance Show MemoryBackend where
-  show _ = "<MemoryBackend>"
+    show _ = "<MemoryBackend>"
 
 instance Backend MemoryBackend where
-  version backend = do
-    totalSize <- totalShareSize backend
-    return Version
-      { applicationVersion = "(memory)"
-      , parameters =
-          Version1Parameters
-          { maximumImmutableShareSize = 1024 * 1024 * 64
-          , maximumMutableShareSize = 1024 * 1024 * 64
-          , availableSpace = (1024 * 1024 * 1024) - totalSize
-          , toleratesImmutableReadOverrun = True
-          , deleteMutableSharesWithZeroLengthWritev = True
-          , fillsHolesWithZeroBytes = True
-          , preventsReadPastEndOfShareData = True
-          -- TODO Doesn't really belong here.  Also we need more than a bool.
-          -- We need to tell them *where* it is available or it is useless.
-          , httpProtocolAvailable = True
-          }
-      }
+    version backend = do
+        totalSize <- totalShareSize backend
+        return
+            Version
+                { applicationVersion = "(memory)"
+                , parameters =
+                    Version1Parameters
+                        { maximumImmutableShareSize = 1024 * 1024 * 64
+                        , maximumMutableShareSize = 1024 * 1024 * 64
+                        , availableSpace = (1024 * 1024 * 1024) - totalSize
+                        , toleratesImmutableReadOverrun = True
+                        , deleteMutableSharesWithZeroLengthWritev = True
+                        , fillsHolesWithZeroBytes = True
+                        , preventsReadPastEndOfShareData = True
+                        , -- TODO Doesn't really belong here.  Also we need more than a bool.
+                          -- We need to tell them *where* it is available or it is useless.
+                          httpProtocolAvailable = True
+                        }
+                }
 
-  createMutableStorageIndex backend storageIndex params =
-    return AllocationResult
-    { alreadyHave = mempty
-    , allocated = shareNumbers params
-    }
+    createMutableStorageIndex :: MemoryBackend -> StorageIndex -> AllocateBuckets -> IO AllocationResult
+    createMutableStorageIndex _backend _storageIndex params =
+        return
+            AllocationResult
+                { alreadyHave = mempty
+                , allocated = shareNumbers params
+                }
 
-  getMutableShareNumbers backend storageIndex = do
-    shares' <- readIORef $ mutableShares backend
-    return $ maybe [] keys $ lookup storageIndex shares'
+    getMutableShareNumbers :: MemoryBackend -> StorageIndex -> IO [ShareNumber]
+    getMutableShareNumbers backend storageIndex = do
+        shares' <- readIORef $ mutableShares backend
+        return $ maybe [] keys $ lookup storageIndex shares'
 
-  readvAndTestvAndWritev
-    backend
-    storageIndex
-    (ReadTestWriteVectors secrets testWritev readv) = do
-    -- TODO implement readv and testv parts.  implement secrets part.
-    let shares = mutableShares backend
-    modifyIORef shares $ addShares storageIndex (shares' testWritev)
-    return ReadTestWriteResult
-      { success = True
-      , readData = mempty
-      }
-      where
-        shares'
-          :: Map ShareNumber TestWriteVectors
-          -> [(ShareNumber, ShareData)]
-        shares' testWritevs =
-          [ (shareNumber, shareData writev)
-          | (shareNumber, testWritev) <- toList testWritevs,
-            writev                    <- write testWritev
-          ]
-
-  createImmutableStorageIndex backend idx params =
-    return AllocationResult
-    { alreadyHave = mempty
-    , allocated = shareNumbers params
-    }
-
-  writeImmutableShare backend storageIndex shareNumber shareData Nothing = do
-    shares <- readIORef (immutableShares backend)
-    changed <- atomicModifyIORef' (immutableShares backend) $
-      \shares ->
-        case lookup storageIndex shares >>= lookup shareNumber of
-          Just _ ->
-            -- It is not allowed to write new data for an immutable share that
-            -- has already been written.
-            (shares, False)
-          Nothing ->
-            (addShares storageIndex [(shareNumber, shareData)] shares, True)
-    if changed
-      then return ()
-      else throwIO ImmutableShareAlreadyWritten
-
-  adviseCorruptImmutableShare backend _ _ _ =
-    return mempty
-
-  getImmutableShareNumbers backend storageIndex = do
-    shares' <- readIORef $ immutableShares backend
-    return $ maybe [] keys $ lookup storageIndex shares'
-
-  readImmutableShares backend storageIndex shareNumbers [] [] = do
-    shares' <- readIORef $ immutableShares backend
-    let result = case lookup storageIndex shares' of
-          Nothing       -> mempty
-          Just shares'' ->
-            let matchingShares = filterWithKey matches shares'' in
-              map (replicate 1) matchingShares
+    readvAndTestvAndWritev :: MemoryBackend -> StorageIndex -> ReadTestWriteVectors -> IO ReadTestWriteResult
+    readvAndTestvAndWritev
+        backend
+        storageIndex
+        (ReadTestWriteVectors _secrets testWritev _readv) = do
+            -- TODO implement readv and testv parts.  implement secrets part.
+            let shares = mutableShares backend
+            modifyIORef shares $ addShares storageIndex (shares' testWritev)
+            return
+                ReadTestWriteResult
+                    { success = True
+                    , readData = mempty
+                    }
           where
-            matches k v = k `elem` shareNumbers
-    return result
+            shares' ::
+                Map ShareNumber TestWriteVectors ->
+                [(ShareNumber, ShareData)]
+            shares' testWritevs =
+                [ (shareNumber, shareData writev)
+                | (shareNumber, testWritev') <- toList testWritevs
+                , writev <- write testWritev'
+                ]
+
+    createImmutableStorageIndex :: MemoryBackend -> StorageIndex -> AllocateBuckets -> IO AllocationResult
+    createImmutableStorageIndex _backend _idx params =
+        return
+            AllocationResult
+                { alreadyHave = mempty
+                , allocated = shareNumbers params
+                }
+
+    writeImmutableShare :: MemoryBackend -> StorageIndex -> ShareNumber -> ShareData -> Maybe ByteRanges -> IO ()
+    writeImmutableShare backend storageIndex shareNumber shareData Nothing = do
+        -- shares <- readIORef (immutableShares backend) -- XXX uh, is this right?!
+        changed <- atomicModifyIORef' (immutableShares backend) $
+            \shares ->
+                case lookup storageIndex shares >>= lookup shareNumber of
+                    Just _ ->
+                        -- It is not allowed to write new data for an immutable share that
+                        -- has already been written.
+                        (shares, False)
+                    Nothing ->
+                        (addShares storageIndex [(shareNumber, shareData)] shares, True)
+        if changed
+            then return ()
+            else throwIO ImmutableShareAlreadyWritten
+    writeImmutableShare _ _ _ _ _ = error "writeImmutableShare got bad input"
+
+    adviseCorruptImmutableShare :: MemoryBackend -> StorageIndex -> ShareNumber -> CorruptionDetails -> IO ()
+    adviseCorruptImmutableShare _backend _ _ _ =
+        return mempty
+
+    getImmutableShareNumbers :: MemoryBackend -> StorageIndex -> IO [ShareNumber]
+    getImmutableShareNumbers backend storageIndex = do
+        shares' <- readIORef $ immutableShares backend
+        return $ maybe [] keys $ lookup storageIndex shares'
+
+    readImmutableShares :: MemoryBackend -> StorageIndex -> [ShareNumber] -> [Offset] -> [Size] -> IO ReadResult
+    readImmutableShares backend storageIndex shareNumbers [] [] = do
+        shares' <- readIORef $ immutableShares backend
+        let result = case lookup storageIndex shares' of
+                Nothing -> mempty
+                Just shares'' ->
+                    let matchingShares = filterWithKey matches shares''
+                     in map (replicate 1) matchingShares
+              where
+                matches k _v = k `elem` shareNumbers
+        return result
+    readImmutableShares _ _ _ _ _ = error "readImmutableShares got bad input"
 
 totalShareSize :: MemoryBackend -> IO Size
 totalShareSize backend = do
-  imm <- readIORef $ immutableShares backend
-  mut <- readIORef $ mutableShares backend
-  let immSize = sum $ map length imm
-  let mutSize = sum $ map length mut
-  return $ toInteger $ immSize + mutSize
+    imm <- readIORef $ immutableShares backend
+    mut <- readIORef $ mutableShares backend
+    let immSize = sum $ map length imm
+    let mutSize = sum $ map length mut
+    return $ toInteger $ immSize + mutSize
 
 addShares :: StorageIndex -> [(ShareNumber, ShareData)] -> ShareStorage -> ShareStorage
-addShares storageIndex [] shareStorage = shareStorage
-addShares storageIndex ((shareNumber, shareData):rest) shareStorage =
-  let added = case lookup storageIndex shareStorage of
-                Nothing      ->
-                  insert storageIndex (fromList [(shareNumber, shareData)]) shareStorage
-
-                Just shares  ->
-                  adjust addShare' storageIndex shareStorage
-                  where
-                    addShare' = insert shareNumber shareData
-  in
-    addShares storageIndex rest added
+addShares _storageIndex [] shareStorage = shareStorage
+addShares storageIndex ((shareNumber, shareData) : rest) shareStorage =
+    let added = case lookup storageIndex shareStorage of
+            Nothing ->
+                insert storageIndex (fromList [(shareNumber, shareData)]) shareStorage
+            Just _shares ->
+                adjust addShare' storageIndex shareStorage
+              where
+                addShare' = insert shareNumber shareData
+     in addShares storageIndex rest added
 
 memoryBackend :: IO MemoryBackend
 memoryBackend = do
-  immutableShares <- newIORef mempty
-  mutableShares <- newIORef mempty
-  buckets <- newIORef mempty
-  return $ MemoryBackend immutableShares mutableShares buckets
+    immutableShares <- newIORef mempty
+    mutableShares <- newIORef mempty
+    buckets <- newIORef mempty
+    return $ MemoryBackend immutableShares mutableShares buckets

--- a/src/TahoeLAFS/Storage/Backend/Null.hs
+++ b/src/TahoeLAFS/Storage/Backend/Null.hs
@@ -1,70 +1,68 @@
-module TahoeLAFS.Storage.Backend.Null
-  ( NullBackend(NullBackend)
-  ) where
+module TahoeLAFS.Storage.Backend.Null (
+    NullBackend (NullBackend),
+) where
 
-import System.Posix.StatVFS
-  ( StatVFS(statVFS_bsize, statVFS_bavail)
-  , statVFS
-  )
+import TahoeLAFS.Storage.API (
+    AllocateBuckets,
+    AllocationResult (..),
+    ApplicationVersion,
+    CorruptionDetails,
+    Offset,
+    ReadResult,
+    ShareData,
+    ShareNumber,
+    Size,
+    StorageIndex,
+    Version (..),
+    Version1Parameters (..),
+ )
 
-import TahoeLAFS.Storage.API
-  ( Version(..)
-  , Size
-  , Offset
-  , StorageIndex
-  , ShareNumber
-  , ShareData
-  , ApplicationVersion(..)
-  , Version1Parameters(..)
-  , AllocationResult(..)
-  )
-
-import TahoeLAFS.Storage.Backend
-  ( Backend(..)
-  )
+import TahoeLAFS.Storage.Backend (
+    Backend (..),
+ )
 
 data NullBackend = NullBackend
-  deriving (Show)
+    deriving (Show)
 
 instance Backend NullBackend where
-  version NullBackend =
-    return Version
-      { applicationVersion = "(null)"
-      , parameters =
-          Version1Parameters
-          { maximumImmutableShareSize = 0
-          , maximumMutableShareSize = 0
-          , availableSpace = 0
-          , toleratesImmutableReadOverrun = False
-          , deleteMutableSharesWithZeroLengthWritev = False
-          , fillsHolesWithZeroBytes = False
-          , preventsReadPastEndOfShareData = False
-          -- TODO Doesn't really belong here.  Also we need more than a bool.
-          -- We need to tell them *where* it is available or it is useless.
-          , httpProtocolAvailable = True
-          }
-      }
+    version NullBackend =
+        return
+            Version
+                { applicationVersion = "(null)"
+                , parameters =
+                    Version1Parameters
+                        { maximumImmutableShareSize = 0
+                        , maximumMutableShareSize = 0
+                        , availableSpace = 0
+                        , toleratesImmutableReadOverrun = False
+                        , deleteMutableSharesWithZeroLengthWritev = False
+                        , fillsHolesWithZeroBytes = False
+                        , preventsReadPastEndOfShareData = False
+                        , -- TODO Doesn't really belong here.  Also we need more than a bool.
+                          -- We need to tell them *where* it is available or it is useless.
+                          httpProtocolAvailable = True
+                        }
+                }
 
-  createImmutableStorageIndex NullBackend _ _ =
-    return AllocationResult
-    { alreadyHave = mempty
-    , allocated = mempty
-    }
+    createImmutableStorageIndex :: NullBackend -> StorageIndex -> AllocateBuckets -> IO AllocationResult
+    createImmutableStorageIndex NullBackend _ _ =
+        return
+            AllocationResult
+                { alreadyHave = mempty
+                , allocated = mempty
+                }
 
-  writeImmutableShare NullBackend _ _ _ _ =
-    return mempty
+    writeImmutableShare NullBackend _ _ _ _ =
+        return mempty
 
-  adviseCorruptImmutableShare NullBackend _ _ _ =
-    return mempty
+    adviseCorruptImmutableShare :: NullBackend -> StorageIndex -> ShareNumber -> CorruptionDetails -> IO ()
+    adviseCorruptImmutableShare NullBackend _ _ _ =
+        return mempty
 
-  getImmutableShareNumbers NullBackend _ =
-    return []
+    getImmutableShareNumbers :: NullBackend -> StorageIndex -> IO [ShareNumber]
+    getImmutableShareNumbers NullBackend _ =
+        return []
 
-  readImmutableShares NullBackend _ _ _ _ =
-    return mempty
-
-  -- createMutableStorageIndex NullBackend _ _ =
-  --   return AllocationResult
-  --   { alreadyHave = mempty
-  --   , allocated = mempty
-  --   }
+    readImmutableShares :: NullBackend -> StorageIndex -> [ShareNumber] -> [Offset] -> [Size] -> IO ReadResult
+    readImmutableShares NullBackend _ _ _ _ =
+        return mempty

--- a/src/TahoeLAFS/Storage/Client.hs
+++ b/src/TahoeLAFS/Storage/Client.hs
@@ -1,37 +1,37 @@
-module TahoeLAFS.Storage.Client
-  ( version
-  , createImmutableStorageIndex
-  , writeImmutableShare
-  , adviseCorruptImmutableShare
-  , getImmutableShareNumbers
-  , readImmutableShares
-  , createMutableStorageIndex
-  , readvAndTestvAndWritev
-  , readMutableShares
-  , getMutableShareNumbers
-  , adviseCorruptMutableShare
-  ) where
+module TahoeLAFS.Storage.Client (
+    version,
+    createImmutableStorageIndex,
+    writeImmutableShare,
+    adviseCorruptImmutableShare,
+    getImmutableShareNumbers,
+    readImmutableShares,
+    createMutableStorageIndex,
+    readvAndTestvAndWritev,
+    readMutableShares,
+    getMutableShareNumbers,
+    adviseCorruptMutableShare,
+) where
 
-import Servant
-  ( (:<|>)(..)
-  )
-import Servant.Client
-  ( client
-  )
+import Servant (
+    (:<|>) (..),
+ )
+import Servant.Client (
+    client,
+ )
 
-import TahoeLAFS.Storage.API
-  ( api
-  )
+import TahoeLAFS.Storage.API (
+    api,
+ )
 
-(version
-  :<|> createImmutableStorageIndex
-  :<|> writeImmutableShare
-  :<|> adviseCorruptImmutableShare
-  :<|> getImmutableShareNumbers
-  :<|> readImmutableShares
-  :<|> createMutableStorageIndex
-  :<|> readvAndTestvAndWritev
-  :<|> readMutableShares
-  :<|> getMutableShareNumbers
-  :<|> adviseCorruptMutableShare
-  ) = client api
+( version
+        :<|> createImmutableStorageIndex
+        :<|> writeImmutableShare
+        :<|> adviseCorruptImmutableShare
+        :<|> getImmutableShareNumbers
+        :<|> readImmutableShares
+        :<|> createMutableStorageIndex
+        :<|> readvAndTestvAndWritev
+        :<|> readMutableShares
+        :<|> getMutableShareNumbers
+        :<|> adviseCorruptMutableShare
+    ) = client api

--- a/src/TahoeLAFS/Storage/Server.hs
+++ b/src/TahoeLAFS/Storage/Server.hs
@@ -1,155 +1,148 @@
-module TahoeLAFS.Storage.Server
-  ( StorageServerConfig(StorageServerConfig)
-  , app
-  , main
-  ) where
+module TahoeLAFS.Storage.Server (
+    StorageServerConfig (StorageServerConfig),
+    app,
+    main,
+) where
 
-import Control.Monad.IO.Class
-  ( liftIO
-  )
+import Control.Monad.IO.Class (
+    liftIO,
+ )
 
-import Control.Exception
-  ( Exception
-  , throw
-  )
+import Control.Exception (
+    Exception,
+    throw,
+ )
 
-import TahoeLAFS.Storage.API
-  ( Version(..)
-  , Size
-  , Offset
-  , StorageIndex
-  , ShareNumber
-  , ShareData
-  , ApplicationVersion(..)
-  , Version1Parameters(..)
-  , AllocateBuckets
-  , AllocationResult(..)
-  , ReadTestWriteVectors
-  , ReadTestWriteResult(..)
-  , ReadVectors
-  , ReadResult
-  , CorruptionDetails
-  , StorageAPI
-  , api
-  )
+import TahoeLAFS.Storage.API (
+    AllocateBuckets,
+    AllocationResult (..),
+    CorruptionDetails,
+    Offset,
+    ReadResult,
+    ReadTestWriteResult (..),
+    ReadTestWriteVectors,
+    ShareData,
+    ShareNumber,
+    Size,
+    StorageAPI,
+    StorageIndex,
+    Version (..),
+    api,
+ )
 
 import qualified TahoeLAFS.Storage.Backend as Backend
-import TahoeLAFS.Storage.Backend.Filesystem
-  ( FilesystemBackend(FilesystemBackend)
-  )
+import TahoeLAFS.Storage.Backend.Filesystem (
+    FilesystemBackend (FilesystemBackend),
+ )
 
-import Servant
-  ( (:<|>)(..)
-  , Server
-  , Handler(Handler)
-  , serve
-  )
+import Servant (
+    Handler,
+    Server,
+    serve,
+    (:<|>) (..),
+ )
 
-import System.IO
-  ( FilePath
-  )
+import Network.HTTP.Types (
+    ByteRanges,
+ )
 
-import Network.HTTP.Types
-  ( ByteRange
-  , ByteRanges
-  )
+import Network.Wai (
+    Application,
+ )
 
-import Network.Wai
-  ( Application
-  )
-import Network.Wai.Handler.Warp
-  ( Port
-  , Settings
-  , runSettings
-  , defaultSettings
-  , setPort
-  )
+import Network.Wai.Handler.Warp (
+    Port,
+    defaultSettings,
+    runSettings,
+    setPort,
+ )
 
-import Network.Wai.Handler.WarpTLS
-  ( TLSSettings
-  , runTLS
-  , tlsSettings
-  )
+import Network.Wai.Handler.WarpTLS (
+    runTLS,
+    tlsSettings,
+ )
 
 version :: Backend.Backend b => b -> Handler Version
 version backend =
-  liftIO (Backend.version backend)
+    liftIO (Backend.version backend)
 
 createImmutableStorageIndex :: Backend.Backend b => b -> StorageIndex -> AllocateBuckets -> Handler AllocationResult
 createImmutableStorageIndex backend storage_index params =
-  liftIO (Backend.createImmutableStorageIndex backend storage_index params)
+    liftIO (Backend.createImmutableStorageIndex backend storage_index params)
 
 writeImmutableShare :: Backend.Backend b => b -> StorageIndex -> ShareNumber -> ShareData -> Maybe ByteRanges -> Handler ()
 writeImmutableShare backend storage_index share_number share_data content_ranges =
-  liftIO (Backend.writeImmutableShare backend storage_index share_number share_data content_ranges)
+    liftIO (Backend.writeImmutableShare backend storage_index share_number share_data content_ranges)
 
 adviseCorruptImmutableShare :: Backend.Backend b => b -> StorageIndex -> ShareNumber -> CorruptionDetails -> Handler ()
 adviseCorruptImmutableShare backend storage_index share_number details =
-  liftIO (Backend.adviseCorruptImmutableShare backend storage_index share_number details)
+    liftIO (Backend.adviseCorruptImmutableShare backend storage_index share_number details)
 
 getImmutableShareNumbers :: Backend.Backend b => b -> StorageIndex -> Handler [ShareNumber]
 getImmutableShareNumbers backend storage_index =
-  liftIO (Backend.getImmutableShareNumbers backend storage_index)
+    liftIO (Backend.getImmutableShareNumbers backend storage_index)
 
 readImmutableShares :: Backend.Backend b => b -> StorageIndex -> [ShareNumber] -> [Offset] -> [Size] -> Handler ReadResult
 readImmutableShares backend storage_index share_numbers offsets sizes =
-  liftIO (Backend.readImmutableShares backend storage_index share_numbers offsets sizes)
+    liftIO (Backend.readImmutableShares backend storage_index share_numbers offsets sizes)
 
 createMutableStorageIndex :: Backend.Backend b => b -> StorageIndex -> AllocateBuckets -> Handler AllocationResult
 createMutableStorageIndex backend storage_index params =
-  liftIO (Backend.createMutableStorageIndex backend storage_index params)
+    liftIO (Backend.createMutableStorageIndex backend storage_index params)
 
 readvAndTestvAndWritev :: Backend.Backend b => b -> StorageIndex -> ReadTestWriteVectors -> Handler ReadTestWriteResult
 readvAndTestvAndWritev backend storage_index vectors =
-  liftIO (Backend.readvAndTestvAndWritev backend storage_index vectors)
+    liftIO (Backend.readvAndTestvAndWritev backend storage_index vectors)
 
 readMutableShares :: Backend.Backend b => b -> StorageIndex -> [ShareNumber] -> [Offset] -> [Size] -> Handler ReadResult
 readMutableShares backend storage_index share_numbers offsets sizes =
-  liftIO (Backend.readMutableShares backend storage_index share_numbers offsets sizes)
+    liftIO (Backend.readMutableShares backend storage_index share_numbers offsets sizes)
 
 getMutableShareNumbers :: Backend.Backend b => b -> StorageIndex -> Handler [ShareNumber]
 getMutableShareNumbers backend storage_index =
-  liftIO (Backend.getMutableShareNumbers backend storage_index)
+    liftIO (Backend.getMutableShareNumbers backend storage_index)
 
 adviseCorruptMutableShare :: Backend.Backend b => b -> StorageIndex -> ShareNumber -> CorruptionDetails -> Handler ()
 adviseCorruptMutableShare backend storage_index share_number details =
-  liftIO (Backend.adviseCorruptMutableShare backend storage_index share_number details)
+    liftIO (Backend.adviseCorruptMutableShare backend storage_index share_number details)
 
 data MisconfiguredTLS = MisconfiguredTLS
-  deriving Show
+    deriving (Show)
 instance Exception MisconfiguredTLS
 
 data StorageServerConfig = StorageServerConfig
-  { storagePath :: FilePath
-  , listenPort  :: Port
-  , certificate :: Maybe FilePath
-  , key         :: Maybe FilePath
-  } deriving (Show, Eq)
+    { storagePath :: FilePath
+    , listenPort :: Port
+    , certificate :: Maybe FilePath
+    , key :: Maybe FilePath
+    }
+    deriving (Show, Eq)
 
 app :: Backend.Backend b => b -> Application
 app backend =
-  serve api storageServer
+    serve api storageServer
   where
     storageServer :: Server StorageAPI
-    storageServer = version backend
-      :<|> createImmutableStorageIndex backend
-      :<|> writeImmutableShare backend
-      :<|> adviseCorruptImmutableShare backend
-      :<|> getImmutableShareNumbers backend
-      :<|> readImmutableShares backend
-      :<|> createMutableStorageIndex backend
-      :<|> readvAndTestvAndWritev backend
-      :<|> readMutableShares backend
-      :<|> getMutableShareNumbers backend
-      :<|> adviseCorruptMutableShare backend
+    storageServer =
+        version backend
+            :<|> createImmutableStorageIndex backend
+            :<|> writeImmutableShare backend
+            :<|> adviseCorruptImmutableShare backend
+            :<|> getImmutableShareNumbers backend
+            :<|> readImmutableShares backend
+            :<|> createMutableStorageIndex backend
+            :<|> readvAndTestvAndWritev backend
+            :<|> readMutableShares backend
+            :<|> getMutableShareNumbers backend
+            :<|> adviseCorruptMutableShare backend
 
 main :: StorageServerConfig -> IO ()
 main config =
-  run $ app (FilesystemBackend $ storagePath config)
+    run $ app (FilesystemBackend $ storagePath config)
   where
     settings = setPort (listenPort config) defaultSettings
     run a =
-      case (certificate config, key config) of
-        (Nothing, Nothing) -> runSettings settings a
-        (Just c, Just k)   -> runTLS (tlsSettings c k) settings a
-        _                  -> throw MisconfiguredTLS
+        case (certificate config, key config) of
+            (Nothing, Nothing) -> runSettings settings a
+            (Just c, Just k) -> runTLS (tlsSettings c k) settings a
+            _ -> throw MisconfiguredTLS

--- a/tahoe-lafs-storage-server.cabal
+++ b/tahoe-lafs-storage-server.cabal
@@ -1,123 +1,167 @@
-name:                tahoe-lafs-storage-server
-version:             0.1.0.0
-synopsis:            A Tahoe-LAFS Storage Server
+cabal-version:      3.0
+name:               tahoe-lafs-storage-server
+version:            0.1.0.0
+build-type:         Simple
 
-description:         This package implements a storage server for Tahoe-LAFS.
-                     It implements the recently proposed "Great Black Swamp"
-                     protocol and not the original Foolscap-based protocol.
+common common-opts
+  default-extensions:
+    GADTs
+    ImportQualifiedPost
+    InstanceSigs
+    LambdaCase
+    MultiWayIf
+    NamedFieldPuns
+    OverloadedStrings
+    RecordWildCards
+    ScopedTypeVariables
+    StrictData
+    TupleSections
+    TypeApplications
 
-homepage:            https://github.com/LeastAuthority/tahoe-lafs-storage-server#readme
-license:             BSD3
-license-file:        LICENSE
-author:              Least Authority TFA GmbH
-maintainer:          jean-paul@leastauthority.com
-copyright:           BSD3
-category:            Cryptography
-                   , Distributed Computing
-                   , Filesystem
-                   , Network
-                   , Network APIs
-                   , Security
-                   , Service
-                   , Storage
-                   , Web
-build-type:          Simple
-cabal-version:       >=1.10
-extra-source-files:  README.rst
+  ghc-options:        -Wall -threaded -rtsopts -with-rtsopts=-N
+  build-depends:
+    , aeson
+    , async
+    , base
+    , binary
+    , bytestring
+    , containers
+    , deriving-aeson
+    , directory
+    , filepath
+    , foldl
+    , http-types
+    , primitive
+    , safe-exceptions
+    , text
+    , unordered-containers
+    , vector
+
+  -- Codecs
+  -- Parallelism
+  -- Mutability
+  -- Binary
+  -- Containers
+  -- Utilities
+  -- the actual app
+
+  default-language:   Haskell2010
+
+synopsis:           A Tahoe-LAFS Storage Server
+description:
+  This package implements a storage server for Tahoe-LAFS.
+  It implements the recently proposed "Great Black Swamp"
+  protocol and not the original Foolscap-based protocol.
+
+homepage:
+  https://github.com/LeastAuthority/tahoe-lafs-storage-server#readme
+
+license:            BSD3
+license-file:       LICENSE
+author:             Least Authority TFA GmbH
+maintainer:         jean-paul@leastauthority.com
+copyright:          BSD3
+category:
+  Cryptography
+  , Distributed Computing
+  , Filesystem
+  , Network
+  , Network APIs
+  , Security
+  , Service
+  , Storage
+  , Web
+
+extra-source-files: README.rst
 
 library
-  hs-source-dirs:      src
-  exposed-modules:     TahoeLAFS.Storage.API
-                     , TahoeLAFS.Storage.APIDocs
-                     , TahoeLAFS.Storage.Backend
-                     , TahoeLAFS.Storage.Backend.Null
-                     , TahoeLAFS.Storage.Backend.Memory
-                     , TahoeLAFS.Storage.Backend.Filesystem
-                     , TahoeLAFS.Storage.Server
-                     , TahoeLAFS.Storage.Client
-  other-modules:       TahoeLAFS.Internal.ServantUtil
-  default-language:    Haskell2010
-  build-depends:       base >= 4.7 && < 5
-                     , containers
-                     , bytestring
-                     , scientific
-                     , base64-bytestring
-                     , text
-                     , utf8-string
-                     , filepath
-                     , directory
-                     , aeson
-                     , cborg
-                     , cborg-json
-                     , http-media
-                     , serialise
-                     , http-api-data
-                     , http-types
-                     , servant-docs
-                     , servant-server
-                     , servant-client
-                     , wai
-                     , warp
-                     , warp-tls
-                     , statvfs
+  import:           common-opts
+  hs-source-dirs:   src
+  exposed-modules:
+    TahoeLAFS.Storage.API
+    TahoeLAFS.Storage.APIDocs
+    TahoeLAFS.Storage.Backend
+    TahoeLAFS.Storage.Backend.Filesystem
+    TahoeLAFS.Storage.Backend.Memory
+    TahoeLAFS.Storage.Backend.Null
+    TahoeLAFS.Storage.Client
+    TahoeLAFS.Storage.Server
 
-executable gbs-generate-apidocs
-  hs-source-dirs:      generate-apidocs
-  main-is:             Main.hs
-  default-language:    Haskell2010
-  build-depends:       base
-                     , servant-docs
-                     , servant-pandoc
-                     , pandoc
-                     , data-default
-                     , blaze-html
-                     , tahoe-lafs-storage-server
-                     , text
+  other-modules:    TahoeLAFS.Internal.ServantUtil
+  default-language: Haskell2010
+  build-depends:
+    , base               >=4.7 && <5
+    , base64-bytestring
+    , cborg
+    , cborg-json
+    , http-api-data
+    , http-media
+    , scientific
+    , serialise
+    , servant-client
+    , servant-docs
+    , servant-server
+    , statvfs
+    , utf8-string
+    , wai
+    , warp
+    , warp-tls
+
+-- executable gbs-generate-apidocs
+--   hs-source-dirs:      generate-apidocs
+--   main-is:             Main.hs
+--   default-language:    Haskell2010
+--   build-depends:       base
+--                      , servant-docs
+--                      , pandoc
+--                      , data-default
+--                      , blaze-html
+--                      , tahoe-lafs-storage-server
+--                      , text
 
 executable tahoe-lafs-storage-server
-  hs-source-dirs:      app
-  main-is:             Main.hs
-  default-language:    Haskell2010
-  build-depends:       base
-                     , optparse-applicative
-                     , tahoe-lafs-storage-server
-                     , warp
+  hs-source-dirs:   app
+  main-is:          Main.hs
+  default-language: Haskell2010
+  build-depends:
+    , base
+    , optparse-applicative
+    , tahoe-lafs-storage-server
+    , warp
 
 executable gbs-generate-clients
-  hs-source-dirs:      generate-clients
-  main-is:             Main.hs
-  default-language:    Haskell2010
-  build-depends:       base
-                     , tahoe-lafs-storage-server
-                     , servant-py
-                     , servant-js
-                     , filepath
+  hs-source-dirs:   generate-clients
+  main-is:          Main.hs
+  default-language: Haskell2010
+  build-depends:
+    , base
+    , filepath
+    , servant-js
+    , tahoe-lafs-storage-server
 
 test-suite http-tests
-  type:                exitcode-stdio-1.0
-  hs-source-dirs:      test
-  main-is:             Main.hs
-  other-modules:       Lib
-                     , Spec
-                     , HTTPSpec
-                     , SemanticSpec
-                     , MiscSpec
-  default-language:    Haskell2010
-  build-depends:       base
-                     , bytestring
-                     , base32string
-                     , text
-                     , containers
-                     , vector
-                     , directory
-                     , temporary
-                     , hspec
-                     , hspec-expectations
-                     , hspec-wai
-                     , QuickCheck
-                     , quickcheck-instances
-                     , hspec-jenkins-lae
-                     , wai-extra
-                     , http-types
-                     , aeson
-                     , tahoe-lafs-storage-server
+  import:           common-opts
+  type:             exitcode-stdio-1.0
+  hs-source-dirs:   test
+  main-is:          Main.hs
+  other-modules:
+    HTTPSpec
+    Lib
+    MiscSpec
+    SemanticSpec
+    Spec
+
+  default-language: Haskell2010
+  ghc-options:      -Wall
+  build-depends:
+    , base
+    , base32string
+    , hspec
+    , hspec-expectations
+    , hspec-wai
+    , QuickCheck
+    , quickcheck-instances
+    , tahoe-lafs-storage-server
+    , temporary
+    , vector
+    , wai-extra

--- a/test/HTTPSpec.hs
+++ b/test/HTTPSpec.hs
@@ -1,127 +1,119 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module HTTPSpec
-  ( spec
-  ) where
+module HTTPSpec (
+    spec,
+) where
 
-import Prelude hiding
-  ( replicate
-  )
+import Prelude hiding (
+    replicate,
+ )
 
-import GHC.Int
-  ( Int64
-  )
-import qualified Data.Vector as Vector
 import qualified Data.Map.Strict as Map
+import qualified Data.Vector as Vector
+import GHC.Int (
+    Int64,
+ )
 
-import Data.Aeson.Types
-  ( Value(String, Number, Array)
-  )
+import Data.Aeson.Types (
+    Value (Array, Number, String),
+ )
 
-import Data.Aeson
-  ( encode
-  )
+import Data.Aeson (
+    encode,
+ )
 
-import Data.Char
-  ( ord
-  )
-
-import Data.ByteString
-  ( ByteString
-  )
+import Data.ByteString (
+    ByteString,
+ )
 
 import qualified Data.ByteString.Lazy as L
 
-import Network.HTTP.Types.Method
-  ( methodPost
-  , methodPut
-  , methodGet
-  )
+import Network.HTTP.Types.Method (
+    methodGet,
+    methodPost,
+    methodPut,
+ )
 
-import Test.Hspec
-  ( Spec
-  , describe
-  , it
-  , shouldBe
-  )
+import Test.Hspec (
+    Spec,
+    describe,
+    it,
+ )
 
-import Test.Hspec.Wai
-  ( WaiSession
-  , with
-  , shouldRespondWith
-  , request
-  , ResponseMatcher(ResponseMatcher)
-  , matchBody
-  , matchStatus
-  , matchHeaders
-  , (<:>)
-  )
+import Test.Hspec.Wai (
+    WaiSession,
+    matchBody,
+    matchHeaders,
+    request,
+    shouldRespondWith,
+    with,
+    (<:>),
+ )
 
-import Test.Hspec.Wai.Matcher
-  ( bodyEquals
-  )
+import Test.Hspec.Wai.Matcher (
+    bodyEquals,
+ )
 
-import Network.Wai.Test
-  ( SResponse
-  )
+import Network.Wai.Test (
+    SResponse,
+ )
 
-import TahoeLAFS.Storage.Backend
-  ( Backend
-  )
+import TahoeLAFS.Storage.Backend.Null (
+    NullBackend (NullBackend),
+ )
 
-import TahoeLAFS.Storage.Backend.Null
-  ( NullBackend(NullBackend)
-  )
-
-import TahoeLAFS.Storage.Server
-  ( app
-  )
+import TahoeLAFS.Storage.Server (
+    app,
+ )
 
 getJSON :: ByteString -> WaiSession st SResponse
 getJSON path =
-  request
-    methodGet
-    path
-    [("Accept", "application/json")]
-    ""
+    request
+        methodGet
+        path
+        [("Accept", "application/json")]
+        ""
 
 postJSON :: ByteString -> L.ByteString -> WaiSession st SResponse
 postJSON path body =
-  request
-    methodPost
-    path
-    [("Content-Type", "application/json"), ("Accept", "application/json")]
-    body
+    request
+        methodPost
+        path
+        [("Content-Type", "application/json"), ("Accept", "application/json")]
+        body
 
 putShare :: ByteString -> Int64 -> WaiSession st SResponse
 putShare path size =
-  request
-    methodPut
-    path
-    [("Content-Type", "application/octet-stream"), ("Accept", "application/json")]
-    (L.replicate size 0xdd)
+    request
+        methodPut
+        path
+        [("Content-Type", "application/octet-stream"), ("Accept", "application/json")]
+        (L.replicate size 0xdd)
 
 allocateBucketsJSON :: L.ByteString
 allocateBucketsJSON =
-  encode $ Map.fromList
-  [ ("renew-secret" :: String, String "abcdefgh")
-  , ("cancel-secret" :: String, String "ijklmnop")
-  , ("share-numbers" :: String, Array (Vector.fromList [Number 1, Number 3, Number 5]))
-  , ("allocated-size" :: String, Number 512)
-  ]
+    encode $
+        Map.fromList
+            [ ("renew-secret" :: String, String "abcdefgh")
+            , ("cancel-secret" :: String, String "ijklmnop")
+            , ("share-numbers" :: String, Array (Vector.fromList [Number 1, Number 3, Number 5]))
+            , ("allocated-size" :: String, Number 512)
+            ]
 
 allocateResultJSON :: L.ByteString
 allocateResultJSON =
-  encode $ Map.fromList
-  [ ("already-have" :: String, Array Vector.empty)
-  , ("allocated" :: String, Array Vector.empty)
-  ]
+    encode $
+        Map.fromList
+            [ ("already-have" :: String, Array Vector.empty)
+            , ("allocated" :: String, Array Vector.empty)
+            ]
 
 corruptionJSON :: L.ByteString
 corruptionJSON =
-  encode $ Map.fromList
-  [ ("reason" :: String, "foo and bar" :: String)
-  ]
+    encode $
+        Map.fromList
+            [ ("reason" :: String, "foo and bar" :: String)
+            ]
 
 sharesResultJSON :: L.ByteString
 -- Simple enough I won't go through Aeson here
@@ -133,44 +125,44 @@ readResultJSON = "{}"
 
 spec :: Spec
 spec = with (return $ app NullBackend) $
-  describe "v1" $ do
-    describe "GET /v1/version" $ do
-      it "responds with OK" $
-        getJSON "/v1/version" `shouldRespondWith` 200
+    describe "v1" $ do
+        describe "GET /v1/version" $ do
+            it "responds with OK" $
+                getJSON "/v1/version" `shouldRespondWith` 200
 
-    describe "POST /v1/immutable/abcdefgh" $ do
-      it "responds with CREATED" $
-        postJSON
-          "/v1/immutable/abcdefgh"
-          allocateBucketsJSON
-          `shouldRespondWith` 201
-          -- TODO: ;charset=utf-8 is just an artifact of Servant, would be
-          -- nice to turn it off and not assert it here.
-          { matchHeaders = ["Content-Type" <:> "application/json;charset=utf-8"]
-          , matchBody = bodyEquals allocateResultJSON
-          }
+        describe "POST /v1/immutable/abcdefgh" $ do
+            it "responds with CREATED" $
+                postJSON
+                    "/v1/immutable/abcdefgh"
+                    allocateBucketsJSON
+                    `shouldRespondWith` 201
+                        { -- TODO: ;charset=utf-8 is just an artifact of Servant, would be
+                          -- nice to turn it off and not assert it here.
+                          matchHeaders = ["Content-Type" <:> "application/json;charset=utf-8"]
+                        , matchBody = bodyEquals allocateResultJSON
+                        }
 
-    describe "PUT /v1/immutable/abcdefgh/1" $ do
-      it "responds with CREATED" $
-        putShare "/v1/immutable/abcdefgh/1" 512 `shouldRespondWith` 201
+        describe "PUT /v1/immutable/abcdefgh/1" $ do
+            it "responds with CREATED" $
+                putShare "/v1/immutable/abcdefgh/1" 512 `shouldRespondWith` 201
 
-    describe "POST /v1/immutable/abcdefgh/1/corrupt" $ do
-      it "responds with OK" $
-        postJSON
-          "/v1/immutable/abcdefgh/1/corrupt"
-          corruptionJSON
-          `shouldRespondWith` 200
+        describe "POST /v1/immutable/abcdefgh/1/corrupt" $ do
+            it "responds with OK" $
+                postJSON
+                    "/v1/immutable/abcdefgh/1/corrupt"
+                    corruptionJSON
+                    `shouldRespondWith` 200
 
-    describe "GET /v1/immutable/abcdefgh/shares" $ do
-      it "responds with OK and a JSON list" $
-        getJSON "/v1/immutable/abcdefgh/shares"
-        `shouldRespondWith` 200
-        { matchBody = bodyEquals sharesResultJSON
-        }
+        describe "GET /v1/immutable/abcdefgh/shares" $ do
+            it "responds with OK and a JSON list" $
+                getJSON "/v1/immutable/abcdefgh/shares"
+                    `shouldRespondWith` 200
+                        { matchBody = bodyEquals sharesResultJSON
+                        }
 
-    describe "GET /v1/immutable/abcdefgh" $ do
-      it "responds with OK and a JSON object" $
-        getJSON "/v1/immutable/abcdefgh"
-        `shouldRespondWith` 200
-        { matchBody = bodyEquals readResultJSON
-        }
+        describe "GET /v1/immutable/abcdefgh" $ do
+            it "responds with OK and a JSON object" $
+                getJSON "/v1/immutable/abcdefgh"
+                    `shouldRespondWith` 200
+                        { matchBody = bodyEquals readResultJSON
+                        }

--- a/test/Lib.hs
+++ b/test/Lib.hs
@@ -1,66 +1,59 @@
 {-# LANGUAGE OverloadedStrings #-}
 
-module Lib
-  ( gen10String
-  , genStorageIndex
-  , positiveIntegers
-  , b32encode
-  , b32decode
-  ) where
+module Lib (
+    gen10String,
+    genStorageIndex,
+    positiveIntegers,
+    b32encode,
+    b32decode,
+) where
 
-import Data.Word
-  ( Word8
-  )
+import Data.Word (
+    Word8,
+ )
 
 import qualified Data.Base32String as Base32
 
-import Data.ByteString
-  ( ByteString
-  , pack
-  )
-
-import Data.ByteString.Char8
-  ( unpack
-  )
+import Data.ByteString (
+    ByteString,
+    pack,
+ )
 
 import qualified Data.Text as Text
 
-import Test.QuickCheck
-  ( Property
-  , Arbitrary(arbitrary)
-  , Gen
-  , forAll
-  , suchThatMap
-  , vectorOf
-  , property
-  )
+import Test.QuickCheck (
+    Arbitrary (arbitrary),
+    Gen,
+    suchThatMap,
+    vectorOf,
+ )
 
 -- Get the Arbitrary ByteString instance.
 import Test.QuickCheck.Instances.ByteString ()
 
-import TahoeLAFS.Storage.API
-  ( StorageIndex
-  , ShareNumber
-  , shareNumber
-  )
+import TahoeLAFS.Storage.API (
+    ShareNumber,
+    StorageIndex,
+    shareNumber,
+ )
 
 gen10String :: Gen String
 gen10String = vectorOf 10 arbitrary
 
 gen10ByteString :: Gen ByteString
 gen10ByteString =
-  suchThatMap (vectorOf 10 (arbitrary :: Gen Word8)) (Just . pack)
+    suchThatMap (vectorOf 10 (arbitrary :: Gen Word8)) (Just . pack)
 
 genStorageIndex :: Gen StorageIndex
 genStorageIndex =
-  suchThatMap gen10ByteString (Just . b32encode)
+    suchThatMap gen10ByteString (Just . b32encode)
 
 positiveIntegers :: Gen Integer
 positiveIntegers =
-  suchThatMap (arbitrary :: Gen Integer) (\i -> Just $ abs i)
+    suchThatMap (arbitrary :: Gen Integer) (Just . abs)
 
 instance Arbitrary ShareNumber where
-  arbitrary = suchThatMap positiveIntegers (\i -> shareNumber i)
+    arbitrary = suchThatMap positiveIntegers shareNumber
 
 b32table :: ByteString
 b32table = "abcdefghijklmnopqrstuvwxyz234567"
@@ -70,4 +63,4 @@ b32encode = Text.unpack . Base32.toText . Base32.fromBytes b32table
 
 b32decode :: String -> ByteString
 b32decode base32 =
-  Base32.toBytes b32table $ Base32.fromText b32table $ Text.pack base32
+    Base32.toBytes b32table $ Base32.fromText b32table $ Text.pack base32

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -1,46 +1,13 @@
 module Main where
 
-import System.IO
-  ( FilePath
-  )
+import Test.Hspec.Runner (
+    hspec,
+ )
 
-import System.IO.Error
-  ( isDoesNotExistError
-  )
-
-import System.Environment
-  ( getEnv
-  )
-
-import Control.Exception
-  ( tryJust
-  )
-
-import Test.Hspec.Formatters.Jenkins
-  ( xmlFormatter
-  )
-
-import Test.Hspec.Runner
-  ( hspec
-  , hspecWith
-  , defaultConfig
-  , configFormatter
-  , configOutputFile
-  )
-
-import Spec
-  ( spec
-  )
+import Spec (
+    spec,
+ )
 
 main :: IO ()
 main = do
-  -- If we're doing CI, just do what CI wants.
-  ci <- tryJust (Just . isDoesNotExistError) $ getEnv "CI"
-  case ci of
-    Left _ -> hspec spec
-    Right _ ->
-      hspecWith
-      defaultConfig
-      { configFormatter = Just xmlFormatter
-      , configOutputFile = Right ("test-results/http-tests/results.xml" :: FilePath)
-      } spec
+    hspec spec

--- a/test/MiscSpec.hs
+++ b/test/MiscSpec.hs
@@ -1,109 +1,115 @@
-module MiscSpec
-  ( spec
-  ) where
+module MiscSpec (
+    spec,
+) where
 
-import Prelude hiding
-  ( toInteger
-  )
+import Prelude hiding (
+    toInteger,
+ )
 
-import Text.Printf
-  ( printf
-  )
+import Text.Printf (
+    printf,
+ )
 
-import Test.Hspec
-  ( Spec
-  , describe
-  , it
-  , shouldBe
-  , shouldNotBe
-  , shouldSatisfy
-  )
+import Test.Hspec (
+    Spec,
+    describe,
+    it,
+    shouldBe,
+    shouldNotBe,
+    shouldSatisfy,
+ )
 
 import qualified Data.ByteString as BS
 
-import Test.QuickCheck
-  ( Gen
-  , Arbitrary(arbitrary)
-  , property
-  , forAll
-  , vectorOf
-  )
+import Test.QuickCheck (
+    Arbitrary (arbitrary),
+    Gen,
+    forAll,
+    property,
+    vectorOf,
+ )
 
-import TahoeLAFS.Storage.API
-  ( toInteger
-  )
+import TahoeLAFS.Storage.API (
+    toInteger,
+ )
 
 -- We also get the Arbitrary ShareNumber instance from here.
-import Lib
-  ( genStorageIndex
-  , b32encode
-  , b32decode
-  )
+import Lib (
+    b32decode,
+    b32encode,
+    genStorageIndex,
+ )
 
-import TahoeLAFS.Storage.Backend.Filesystem
-  ( partitionM
-  , storageStartSegment
-  , pathOfShare
-  , incomingPathOf
-  )
+import TahoeLAFS.Storage.Backend.Filesystem (
+    incomingPathOf,
+    partitionM,
+    pathOfShare,
+    storageStartSegment,
+ )
 
 spec :: Spec
 spec = do
-  describe "partitionM" $
-    it "handles empty lists" $
-    partitionM (\e -> return True) ([]::[(Integer,Integer)]) `shouldBe` (Just ([], []))
+    describe "partitionM" $
+        it "handles empty lists" $
+            partitionM (\e -> return True) ([] :: [(Integer, Integer)]) `shouldBe` (Just ([], []))
 
-  describe "partitionM" $
-    it "puts matching elements in the first list and non-matching in the second" $
-    partitionM (\e -> return $ (e `mod` 2) == 0) [5, 5, 6, 7, 8, 8]
-    `shouldBe`
-    (Just ([6, 8, 8], [5, 5, 7]))
+    describe "partitionM" $
+        it "puts matching elements in the first list and non-matching in the second" $
+            partitionM (\e -> return $ (e `mod` 2) == 0) [5, 5, 6, 7, 8, 8]
+                `shouldBe` (Just ([6, 8, 8], [5, 5, 7]))
 
-  describe "storageStartSegment" $
-    it "returns a string of length 2" $ property $
-    forAll genStorageIndex (\storageIndex -> length (storageStartSegment storageIndex) `shouldBe` 2)
+    describe "storageStartSegment" $
+        it "returns a string of length 2" $
+            property $
+                forAll genStorageIndex (\storageIndex -> length (storageStartSegment storageIndex) `shouldBe` 2)
 
-  describe "pathOfShare" $
-    it "returns a path reflecting the storage index and share number" $ property $
-    forAll genStorageIndex
-    (\storageIndex shareNumber ->
-       pathOfShare "/foo" storageIndex shareNumber
-       `shouldBe`
-       (printf "/foo/shares/%s/%s/%d" (take 2 storageIndex) storageIndex (toInteger shareNumber))
-    )
+    describe "pathOfShare" $
+        it "returns a path reflecting the storage index and share number" $
+            property $
+                forAll
+                    genStorageIndex
+                    ( \storageIndex shareNumber ->
+                        pathOfShare "/foo" storageIndex shareNumber
+                            `shouldBe` (printf "/foo/shares/%s/%s/%d" (take 2 storageIndex) storageIndex (toInteger shareNumber))
+                    )
 
-  describe "incomingPathOf" $
-    it "returns a path reflecting the storage index and share number" $ property $
-    forAll genStorageIndex
-    (\storageIndex shareNumber ->
-       incomingPathOf "/foo" storageIndex shareNumber
-       `shouldBe`
-       (printf "/foo/shares/incoming/%s/%s/%d" (take 2 storageIndex) storageIndex (toInteger shareNumber))
-    )
+    describe "incomingPathOf" $
+        it "returns a path reflecting the storage index and share number" $
+            property $
+                forAll
+                    genStorageIndex
+                    ( \storageIndex shareNumber ->
+                        incomingPathOf "/foo" storageIndex shareNumber
+                            `shouldBe` (printf "/foo/shares/incoming/%s/%s/%d" (take 2 storageIndex) storageIndex (toInteger shareNumber))
+                    )
 
-  describe "incomingPathOf vs pathOfShare" $
-    it "returns different paths" $ property $
-    forAll genStorageIndex
-    (\storageIndex shareNumber ->
-       let path = pathOfShare "/foo" storageIndex shareNumber
-           incoming = incomingPathOf "/foo" storageIndex shareNumber
-       in
-         path `shouldNotBe` incoming
-    )
+    describe "incomingPathOf vs pathOfShare" $
+        it "returns different paths" $
+            property $
+                forAll
+                    genStorageIndex
+                    ( \storageIndex shareNumber ->
+                        let path = pathOfShare "/foo" storageIndex shareNumber
+                            incoming = incomingPathOf "/foo" storageIndex shareNumber
+                         in path `shouldNotBe` incoming
+                    )
 
-  describe "base32 round-trip" $
-    it "b32encode and b32decode are inverses" $ property $
-    \bs -> (b32decode . b32encode) bs `shouldBe` bs
+    describe "base32 round-trip" $
+        it "b32encode and b32decode are inverses" $
+            property $
+                \bs -> (b32decode . b32encode) bs `shouldBe` bs
 
-  describe "base32 alphabet" $
-    it "encodes using only the base32 alphabet" $ property $
-    \bs -> b32encode bs `shouldSatisfy` (onlyContains "abcdefghijklmnopqrstuvwxyz234567")
+    describe "base32 alphabet" $
+        it "encodes using only the base32 alphabet" $
+            property $
+                \bs -> b32encode bs `shouldSatisfy` (onlyContains "abcdefghijklmnopqrstuvwxyz234567")
 
-  describe "size ratio" $
-    it "encodes to a string no more than twice the length" $ property $
-    \bs -> b32encode bs `shouldSatisfy` (\base32 -> length base32 <= 2 * BS.length bs)
+    describe "size ratio" $
+        it "encodes to a string no more than twice the length" $
+            property $
+                \bs -> b32encode bs `shouldSatisfy` (\base32 -> length base32 <= 2 * BS.length bs)
 
 -- Does the second list contain only elements of the first list?
 onlyContains :: (Eq a) => [a] -> [a] -> Bool
 onlyContains xs [] = True
-onlyContains xs (y:ys) = y `elem` xs && onlyContains xs ys
+onlyContains xs (y : ys) = y `elem` xs && onlyContains xs ys

--- a/test/SemanticSpec.hs
+++ b/test/SemanticSpec.hs
@@ -1,361 +1,365 @@
-module SemanticSpec
-  ( spec
-  ) where
+module SemanticSpec (
+    spec,
+) where
 
-import Prelude hiding
-  ( toInteger
-  , lookup
-  )
+import Prelude hiding (
+    lookup,
+    toInteger,
+ )
 
-import Control.Monad
-  ( when
-  )
+import Control.Monad (
+    when,
+ )
 
-import Control.Exception
-  ( bracket
-  )
+import Data.Maybe (
+    catMaybes,
+ )
 
-import Data.Maybe
-  ( catMaybes
-  )
+import Data.Bits (
+    xor,
+ )
 
-import Data.Bits
-  ( xor
-  )
-
-import GHC.Word
-  ( Word8
-  )
+import GHC.Word (
+    Word8,
+ )
 
 import qualified Data.Set as Set
 
-import System.Directory
-  ( removeDirectoryRecursive
-  )
+import System.Directory (
+    removeDirectoryRecursive,
+ )
 
-import System.IO.Temp
-  ( getCanonicalTemporaryDirectory
-  , createTempDirectory
-  )
+import System.IO.Temp (
+    createTempDirectory,
+    getCanonicalTemporaryDirectory,
+ )
 
-import Test.Hspec
-  ( Spec
-  , SpecWith
-  , context
-  , describe
-  , it
-  , shouldBe
-  , around
-  , before
-  , beforeWith
-  , shouldThrow
-  )
-import Test.Hspec.Expectations
-  ( Selector
-  )
-import Test.QuickCheck
-  ( Property
-  , Arbitrary(arbitrary)
-  , Gen
-  , forAll
-  , suchThatMap
-  , vectorOf
-  , property
-  )
+import Test.Hspec (
+    Spec,
+    SpecWith,
+    around,
+    before,
+    beforeWith,
+    context,
+    describe,
+    it,
+    shouldBe,
+    shouldThrow,
+ )
+import Test.Hspec.Expectations (
+    Selector,
+ )
+import Test.QuickCheck (
+    Arbitrary (arbitrary),
+    Gen,
+    Property,
+    forAll,
+    property,
+    suchThatMap,
+    vectorOf,
+ )
 
-import Test.QuickCheck.Monadic
-  ( monadicIO
-  , assert
-  , pre
-  , run
-  )
+import Test.QuickCheck.Monadic (
+    assert,
+    monadicIO,
+    pre,
+    run,
+ )
 
 import qualified Test.QuickCheck.Instances.ByteString
 
-import Data.ByteString
-  ( ByteString
-  , map
-  , concat
-  , length
-  )
+import Data.ByteString (
+    ByteString,
+    concat,
+    length,
+    map,
+ )
 
-import Data.List
-  ( sort
-  )
+import Data.List (
+    sort,
+ )
 
-import Data.Map.Strict
-  ( lookup
-  )
+import Data.Map.Strict (
+    lookup,
+ )
 
-import TahoeLAFS.Storage.API
-  ( Size
-  , StorageIndex
-  , ShareNumber
-  , ShareData
-  , AllocateBuckets(AllocateBuckets)
-  , SlotSecrets(..)
-  , alreadyHave
-  , allocated
-  , shareNumber
-  , toInteger
-  )
+import TahoeLAFS.Storage.API (
+    AllocateBuckets (AllocateBuckets),
+    ShareData,
+    ShareNumber,
+    Size,
+    SlotSecrets (..),
+    StorageIndex,
+    allocated,
+    alreadyHave,
+    shareNumber,
+    toInteger,
+ )
 
-import TahoeLAFS.Storage.Backend
-  ( ImmutableShareAlreadyWritten
-  , Backend
-    (createImmutableStorageIndex
-    , writeImmutableShare
-    , readImmutableShares
-    , getImmutableShareNumbers
-
-    , createMutableStorageIndex
-    , getMutableShareNumbers
-    )
-  , writeMutableShare
-  )
+import TahoeLAFS.Storage.Backend (
+    Backend (
+        createImmutableStorageIndex,
+        createMutableStorageIndex,
+        getImmutableShareNumbers,
+        getMutableShareNumbers,
+        readImmutableShares,
+        writeImmutableShare
+    ),
+    ImmutableShareAlreadyWritten,
+    writeMutableShare,
+ )
 
 -- We also get the Arbitrary ShareNumber instance from here.
-import Lib
-  ( genStorageIndex
-  )
+import Lib (
+    genStorageIndex,
+ )
 
-import TahoeLAFS.Storage.Backend.Memory
-  ( MemoryBackend
-  , memoryBackend
-  )
+import TahoeLAFS.Storage.Backend.Memory (
+    MemoryBackend,
+    memoryBackend,
+ )
 
-import TahoeLAFS.Storage.Backend.Filesystem
-  ( FilesystemBackend(FilesystemBackend)
-  )
+import TahoeLAFS.Storage.Backend.Filesystem (
+    FilesystemBackend (FilesystemBackend),
+ )
 
 isUnique :: Ord a => [a] -> Bool
-isUnique xs = Prelude.length xs == (Prelude.length $ Set.toList $ Set.fromList xs)
+isUnique xs = Prelude.length xs == Prelude.length (Set.toList $ Set.fromList xs)
 
+-- XXX null ?
 hasElements :: [a] -> Bool
-hasElements [] = False
-hasElements xs = True
+hasElements = not . null
 
 permuteShare :: ByteString -> ShareNumber -> ByteString
 permuteShare seed number =
-  Data.ByteString.map xor' seed
+    Data.ByteString.map xor' seed
   where
     xor' :: Word8 -> Word8
     xor' = xor $ fromInteger $ toInteger number
 
-writeShares
-  :: (ShareNumber -> ShareData -> Maybe a -> IO ())
-  -> [(ShareNumber, ShareData)] -> IO ()
-writeShares write [] = return ()
-writeShares write ((shareNumber, shareData):rest) = do
-  -- TODO For now we'll do single complete writes.  Later try breaking up the data.
-  write shareNumber shareData Nothing
-  writeShares write rest
+writeShares ::
+    (ShareNumber -> ShareData -> Maybe a -> IO ()) ->
+    [(ShareNumber, ShareData)] ->
+    IO ()
+writeShares _write [] = return ()
+writeShares write ((shareNumber, shareData) : rest) = do
+    -- TODO For now we'll do single complete writes.  Later try breaking up the data.
+    write shareNumber shareData Nothing
+    writeShares write rest
 
 -- In the result of creating an immutable storage index, the sum of
 -- ``alreadyHave`` and ``allocated`` equals ``shareNumbers`` from the input.
-alreadyHavePlusAllocatedImm
-  :: Backend b
-  => b                -- The backend on which to operate
-  -> StorageIndex     -- The storage index to use
-  -> [ShareNumber]    -- The share numbers to allocate
-  -> Size             -- The size of each share
-  -> Property
+alreadyHavePlusAllocatedImm ::
+    Backend b =>
+    b -> -- The backend on which to operate
+    StorageIndex -> -- The storage index to use
+    [ShareNumber] -> -- The share numbers to allocate
+    Size -> -- The size of each share
+    Property
 alreadyHavePlusAllocatedImm backend storageIndex shareNumbers size = monadicIO $ do
-  pre (isUnique shareNumbers)
-  pre (hasElements shareNumbers)
-  result <- run $ createImmutableStorageIndex backend storageIndex $ AllocateBuckets "renew" "cancel" shareNumbers size
-  when ((alreadyHave result) ++ (allocated result) /= shareNumbers)
-    $ fail (show (alreadyHave result)
-            ++ " ++ "
-            ++ show (allocated result)
-            ++ " /= "
-            ++ (show shareNumbers)
-           )
+    pre (isUnique shareNumbers)
+    pre (hasElements shareNumbers)
+    result <- run $ createImmutableStorageIndex backend storageIndex $ AllocateBuckets "renew" "cancel" shareNumbers size
+    when (alreadyHave result ++ allocated result /= shareNumbers) $
+        fail
+            ( show (alreadyHave result)
+                ++ " ++ "
+                ++ show (allocated result)
+                ++ " /= "
+                ++ show shareNumbers
+            )
 
 -- In the result of creating a mutable storage index, the sum of
 -- ``alreadyHave`` and ``allocated`` equals ``shareNumbers`` from the input.
-alreadyHavePlusAllocatedMut
-  :: Backend b
-  => b                -- The backend on which to operate
-  -> StorageIndex     -- The storage index to use
-  -> [ShareNumber]    -- The share numbers to allocate
-  -> Size             -- The size of each share
-  -> Property
+alreadyHavePlusAllocatedMut ::
+    Backend b =>
+    b -> -- The backend on which to operate
+    StorageIndex -> -- The storage index to use
+    [ShareNumber] -> -- The share numbers to allocate
+    Size -> -- The size of each share
+    Property
 alreadyHavePlusAllocatedMut backend storageIndex shareNumbers size = monadicIO $ do
-  pre (isUnique shareNumbers)
-  pre (hasElements shareNumbers)
-  result <- run $ createMutableStorageIndex backend storageIndex $ AllocateBuckets "renew" "cancel" shareNumbers size
-  when ((alreadyHave result) ++ (allocated result) /= shareNumbers)
-    $ fail (show (alreadyHave result)
-            ++ " ++ "
-            ++ show (allocated result)
-            ++ " /= "
-            ++ (show shareNumbers)
-           )
+    pre (isUnique shareNumbers)
+    pre (hasElements shareNumbers)
+    result <- run $ createMutableStorageIndex backend storageIndex $ AllocateBuckets "renew" "cancel" shareNumbers size
+    when (alreadyHave result ++ allocated result /= shareNumbers) $
+        fail
+            ( show (alreadyHave result)
+                ++ " ++ "
+                ++ show (allocated result)
+                ++ " /= "
+                ++ show shareNumbers
+            )
 
 -- The share numbers of immutable share data written to the shares of a given
 -- storage index can be retrieved.
-immutableWriteAndEnumerateShares
-  :: Backend b
-  => b
-  -> StorageIndex
-  -> [ShareNumber]
-  -> ByteString
-  -> Property
+immutableWriteAndEnumerateShares ::
+    Backend b =>
+    b ->
+    StorageIndex ->
+    [ShareNumber] ->
+    ByteString ->
+    Property
 immutableWriteAndEnumerateShares backend storageIndex shareNumbers shareSeed = monadicIO $ do
-  pre (isUnique shareNumbers)
-  pre (hasElements shareNumbers)
-  let permutedShares = Prelude.map (permuteShare shareSeed) shareNumbers
-  let size = fromIntegral (Data.ByteString.length shareSeed)
-  let allocate = AllocateBuckets "renew" "cancel" shareNumbers size
-  result <- run $ createImmutableStorageIndex backend storageIndex allocate
-  run $ writeShares (writeImmutableShare backend storageIndex) (zip shareNumbers permutedShares)
-  readShareNumbers <- run $ getImmutableShareNumbers backend storageIndex
-  let sreadShareNumbers = sort readShareNumbers
-  let sshareNumbers = sort shareNumbers
-  when (sreadShareNumbers /= sshareNumbers) $
-    fail (show sreadShareNumbers ++ " /= " ++ show sshareNumbers)
+    pre (isUnique shareNumbers)
+    pre (hasElements shareNumbers)
+    let permutedShares = Prelude.map (permuteShare shareSeed) shareNumbers
+    let size = fromIntegral (Data.ByteString.length shareSeed)
+    let allocate = AllocateBuckets "renew" "cancel" shareNumbers size
+    _result <- run $ createImmutableStorageIndex backend storageIndex allocate
+    run $ writeShares (writeImmutableShare backend storageIndex) (zip shareNumbers permutedShares)
+    readShareNumbers <- run $ getImmutableShareNumbers backend storageIndex
+    let sreadShareNumbers = sort readShareNumbers
+    let sshareNumbers = sort shareNumbers
+    when (sreadShareNumbers /= sshareNumbers) $
+        fail (show sreadShareNumbers ++ " /= " ++ show sshareNumbers)
 
 -- Immutable share data written to the shares of a given storage index cannot
 -- be rewritten by a subsequent writeImmutableShare operation.
-immutableWriteAndRewriteShare
-  :: Backend b
-  => b
-  -> StorageIndex
-  -> [ShareNumber]
-  -> ByteString
-  -> Property
+immutableWriteAndRewriteShare ::
+    Backend b =>
+    b ->
+    StorageIndex ->
+    [ShareNumber] ->
+    ByteString ->
+    Property
 immutableWriteAndRewriteShare backend storageIndex shareNumbers shareSeed = monadicIO $ do
-  pre (isUnique shareNumbers)
-  pre (hasElements shareNumbers)
-  let size = fromIntegral (Data.ByteString.length shareSeed)
-  let allocate = AllocateBuckets "renew" "cancel" shareNumbers size
-  let aShareNumber = head shareNumbers
-  let aShare = permuteShare shareSeed aShareNumber
-  let write =
-        writeImmutableShare backend storageIndex aShareNumber aShare Nothing
-  run $ do
-    createImmutableStorageIndex backend storageIndex allocate
-    write
-    write `shouldThrow` (const True :: Selector ImmutableShareAlreadyWritten)
+    pre (isUnique shareNumbers)
+    pre (hasElements shareNumbers)
+    let size = fromIntegral (Data.ByteString.length shareSeed)
+    let allocate = AllocateBuckets "renew" "cancel" shareNumbers size
+    let aShareNumber = head shareNumbers
+    let aShare = permuteShare shareSeed aShareNumber
+    let write =
+            writeImmutableShare backend storageIndex aShareNumber aShare Nothing
+    run $ do
+        _ <- createImmutableStorageIndex backend storageIndex allocate
+        write
+        write `shouldThrow` (const True :: Selector ImmutableShareAlreadyWritten)
 
 -- Immutable share data written to the shares of a given storage index can be
 -- retrieved verbatim and associated with the same share numbers as were
 -- specified during writing.
-immutableWriteAndReadShare
-  :: Backend b
-  => b
-  -> StorageIndex
-  -> [ShareNumber]
-  -> ByteString
-  -> Property
+immutableWriteAndReadShare ::
+    Backend b =>
+    b ->
+    StorageIndex ->
+    [ShareNumber] ->
+    ByteString ->
+    Property
 immutableWriteAndReadShare backend storageIndex shareNumbers shareSeed = monadicIO $ do
-  pre (isUnique shareNumbers)
-  pre (hasElements shareNumbers)
-  let permutedShares = Prelude.map (permuteShare shareSeed) shareNumbers
-  let size = fromIntegral (Data.ByteString.length shareSeed)
-  let allocate = AllocateBuckets "renew" "cancel" shareNumbers size
-  result <- run $ createImmutableStorageIndex backend storageIndex allocate
-  run $ writeShares (writeImmutableShare backend storageIndex) (zip shareNumbers permutedShares)
-  readShares' <- run $ readShares backend storageIndex shareNumbers
-  when (permutedShares /= readShares') $
-    fail (show permutedShares ++ " /= " ++ show readShares')
+    pre (isUnique shareNumbers)
+    pre (hasElements shareNumbers)
+    let permutedShares = Prelude.map (permuteShare shareSeed) shareNumbers
+    let size = fromIntegral (Data.ByteString.length shareSeed)
+    let allocate = AllocateBuckets "renew" "cancel" shareNumbers size
+    _result <- run $ createImmutableStorageIndex backend storageIndex allocate
+    run $ writeShares (writeImmutableShare backend storageIndex) (zip shareNumbers permutedShares)
+    readShares' <- run $ readShares backend storageIndex shareNumbers
+    when (permutedShares /= readShares') $
+        fail (show permutedShares ++ " /= " ++ show readShares')
   where
     readShares :: Backend b => b -> StorageIndex -> [ShareNumber] -> IO [ShareData]
     readShares b storageIndex shareNumbers = do
-      -- Map ShareNumber [ShareData]
-      shares <- readImmutableShares b storageIndex shareNumbers [] []
-      let maybeShares = (Prelude.map (flip lookup shares) shareNumbers)
-      let orderedShares = catMaybes maybeShares
-      let shareData = (Prelude.map Data.ByteString.concat orderedShares) :: [ShareData]
-      return shareData
+        -- Map ShareNumber [ShareData]
+        shares <- readImmutableShares b storageIndex shareNumbers [] []
+        let maybeShares = Prelude.map (`lookup` shares) shareNumbers
+        let orderedShares = catMaybes maybeShares
+        let shareData = Prelude.map Data.ByteString.concat orderedShares :: [ShareData]
+        return shareData
 
 -- The share numbers of mutable share data written to the shares of a given
 -- storage index can be retrieved.
-mutableWriteAndEnumerateShares
-  :: Backend b
-  => b
-  -> StorageIndex
-  -> [ShareNumber]
-  -> ByteString
-  -> Property
+mutableWriteAndEnumerateShares ::
+    Backend b =>
+    b ->
+    StorageIndex ->
+    [ShareNumber] ->
+    ByteString ->
+    Property
 mutableWriteAndEnumerateShares backend storageIndex shareNumbers shareSeed = monadicIO $ do
-  pre (isUnique shareNumbers)
-  pre (hasElements shareNumbers)
-  let permutedShares = Prelude.map (permuteShare shareSeed) shareNumbers
-  let size = fromIntegral (Data.ByteString.length shareSeed)
-  let allocate = AllocateBuckets "renew" "cancel" shareNumbers size
-  let nullSecrets = SlotSecrets
-                    { writeEnabler = ""
-                    , leaseRenew = ""
-                    , leaseCancel = ""
-                    }
-  result <- run $ createMutableStorageIndex backend storageIndex allocate
-  run $ writeShares (writeMutableShare backend nullSecrets storageIndex) (zip shareNumbers permutedShares)
-  readShareNumbers <- run $ getMutableShareNumbers backend storageIndex
-  let sreadShareNumbers = sort readShareNumbers
-  let sshareNumbers = sort shareNumbers
-  when (sreadShareNumbers /= sshareNumbers) $
-    fail (show sreadShareNumbers ++ " /= " ++ show sshareNumbers)
+    pre (isUnique shareNumbers)
+    pre (hasElements shareNumbers)
+    let permutedShares = Prelude.map (permuteShare shareSeed) shareNumbers
+    let size = fromIntegral (Data.ByteString.length shareSeed)
+    let allocate = AllocateBuckets "renew" "cancel" shareNumbers size
+    let nullSecrets =
+            SlotSecrets
+                { writeEnabler = ""
+                , leaseRenew = ""
+                , leaseCancel = ""
+                }
+    _result <- run $ createMutableStorageIndex backend storageIndex allocate
+    run $ writeShares (writeMutableShare backend nullSecrets storageIndex) (zip shareNumbers permutedShares)
+    readShareNumbers <- run $ getMutableShareNumbers backend storageIndex
+    let sreadShareNumbers = sort readShareNumbers
+    let sshareNumbers = sort shareNumbers
+    when (sreadShareNumbers /= sshareNumbers) $
+        fail (show sreadShareNumbers ++ " /= " ++ show sshareNumbers)
 
 -- The specification for a storage backend.
 storageSpec :: Backend b => SpecWith b
 storageSpec =
-  context "v1" $ do
-  context "immutable" $ do
-    describe "allocate a storage index" $
-      it "accounts for all allocated share numbers" $ \backend -> property $
-      forAll genStorageIndex (alreadyHavePlusAllocatedImm backend)
+    context "v1" $ do
+        context "immutable" $ do
+            describe "allocate a storage index" $
+                it "accounts for all allocated share numbers" $ \backend ->
+                    property $
+                        forAll genStorageIndex (alreadyHavePlusAllocatedImm backend)
 
-    context "write a share" $ do
-      it "returns the share numbers that were written" $ \backend -> property $
-        forAll genStorageIndex (immutableWriteAndEnumerateShares backend)
+            context "write a share" $ do
+                it "returns the share numbers that were written" $ \backend ->
+                    property $
+                        forAll genStorageIndex (immutableWriteAndEnumerateShares backend)
 
-      it "returns the written data when requested" $ \backend -> property $
-        forAll genStorageIndex (immutableWriteAndReadShare backend)
+                it "returns the written data when requested" $ \backend ->
+                    property $
+                        forAll genStorageIndex (immutableWriteAndReadShare backend)
 
-      it "cannot be written more than once" $ \backend -> property $
-        forAll genStorageIndex (immutableWriteAndRewriteShare backend)
+                it "cannot be written more than once" $ \backend ->
+                    property $
+                        forAll genStorageIndex (immutableWriteAndRewriteShare backend)
 
-  context "mutable" $ do
-    describe "allocate a storage index" $ do
-      it "accounts for all allocated share numbers" $ \backend -> property $
-        forAll genStorageIndex (alreadyHavePlusAllocatedMut backend)
+        context "mutable" $ do
+            describe "allocate a storage index" $ do
+                it "accounts for all allocated share numbers" $ \backend ->
+                    property $
+                        forAll genStorageIndex (alreadyHavePlusAllocatedMut backend)
 
-    describe "write a share" $ do
-      it "returns the share numbers that were written" $ \backend -> property $
-        forAll genStorageIndex (mutableWriteAndEnumerateShares backend)
+            describe "write a share" $ do
+                it "returns the share numbers that were written" $ \backend ->
+                    property $
+                        forAll genStorageIndex (mutableWriteAndEnumerateShares backend)
 
 spec :: Spec
 spec = do
-  Test.Hspec.context "memory" $
-    Test.Hspec.before memoryBackend storageSpec
+    Test.Hspec.context "memory" $
+        Test.Hspec.before memoryBackend storageSpec
 
-  Test.Hspec.context "filesystem" $
-    Test.Hspec.around (withBackend filesystemBackend) storageSpec
+    Test.Hspec.context "filesystem" $
+        Test.Hspec.around (withBackend filesystemBackend) storageSpec
 
 filesystemBackend :: IO FilesystemBackend
 filesystemBackend = do
-  path <- createTemporaryDirectory
-  return $ FilesystemBackend path
+    FilesystemBackend <$> createTemporaryDirectory
 
 createTemporaryDirectory :: IO FilePath
 createTemporaryDirectory = do
-  parent <- getCanonicalTemporaryDirectory
-  createTempDirectory parent "gbs-semanticspec"
+    parent <- getCanonicalTemporaryDirectory
+    createTempDirectory parent "gbs-semanticspec"
 
 class Mess m where
-  -- Cleanup resources belonging to m
-  cleanup :: m -> IO ()
+    -- Cleanup resources belonging to m
+    cleanup :: m -> IO ()
 
 instance Mess FilesystemBackend where
-  cleanup (FilesystemBackend path) = removeDirectoryRecursive path
+    cleanup (FilesystemBackend path) = removeDirectoryRecursive path
 
 instance Mess MemoryBackend where
-  cleanup _ = return ()
+    cleanup _ = return ()
 
 withBackend :: (Mess b, Backend b) => IO b -> ((b -> IO ()) -> IO ())
-withBackend b = \action -> do
-  backend <- b
-  action backend
-  cleanup backend
+withBackend b action = do
+    backend <- b
+    action backend
+    cleanup backend


### PR DESCRIPTION
This is a first stab at lint and reformat.

This PR removes servant-py and servant-pandoc.
This PR also removes statvfs since it wasn't in use anywhere! 